### PR TITLE
fix compile errors

### DIFF
--- a/design/dsl/action.go
+++ b/design/dsl/action.go
@@ -107,20 +107,18 @@ func Params(dsl func()) {
 }
 
 // Payload defines the action payload DSL.
-func Payload(p interface{}) {
+func Payload(dsl func()) {
 	if a, ok := actionDefinition(); ok {
-		if at, ok := p.(*design.AttributeDefinition); ok {
-			a.Payload = at
-			return
-		}
 		rn := inflect.Camelize(a.Resource.Name)
 		an := inflect.Camelize(a.Name)
-		a.Payload = &design.UserTypeDefinition{
-			AttributeDefinition: new(design.AttributeDefinition),
+		a.Payload = &UserTypeDefinition{
+			AttributeDefinition: new(AttributeDefinition),
 			Name:                fmt.Sprintf("%s%sPayload", an, rn),
 		}
+
+		payload := new(UserTypeDefinition)
 		if executeDSL(dsl, &payload) {
-			a.Payload = &payload
+			a.Payload = payload
 		}
 	}
 }

--- a/design/dsl/api.go
+++ b/design/dsl/api.go
@@ -43,13 +43,34 @@ func API(name string, dsl func()) error {
 	return nil // Need to return something for 'var _ = ' trick
 }
 
-// BaseParams defines the API base params
-func BaseParams(attributes ...*AttributeDefinition) {
+// Description sets the description of the source
+func Description(desc string) {
 	switch c := ctxStack.current().(type) {
 	case *APIDefinition:
-		c.BaseParams = attributes
+		c.Description = desc
+	case *ResourceDefinition:
+		c.Description = desc
+	case *TypeDefinition:
+		c.Description = desc
+	case *ActionDefinition:
+		c.Description = desc
+	case *AttributeDefinition:
+		c.Description = desc
+	case *LinkDefinition:
+		c.Description = desc
+	case *ResponseDefinition:
+		c.Description = desc
+	case *UserTypeDefinition:
+		c.Description = desc
 	default:
-		incompatibleDsl("BaseParams")
+		incompatibleDsl("Description")
+	}
+}
+
+// BaseParams defines the API base params
+func BaseParams(dsl func()) {
+	if a, ok := apiDefinition(); ok {
+		executeDSL(dsl, &a)
 	}
 }
 
@@ -67,7 +88,7 @@ func ResponseTemplate(name string, dsl func()) {
 			appendError(fmt.Errorf("multiple definitions for response template %s", name))
 			return
 		}
-		template := &ResponseTemplateDefinition{Name: name}
+		template := &ResponseDefinition{Name: name}
 		if ok := executeDSL(dsl, template); ok {
 			a.ResponseTemplates[name] = template
 		}

--- a/design/dsl/attribute.go
+++ b/design/dsl/attribute.go
@@ -142,8 +142,6 @@ func MaxLength(val int) {
 // Required properties validation
 func Required(names ...string) {
 	if a, ok := attributeDefinition(); ok {
-		if a.Type.Kind() != ObjectType {
 			a.Validations = append(a.Validations, NewRequiredValidation(names...))
-		}
 	}
 }

--- a/design/dsl/media_type.go
+++ b/design/dsl/media_type.go
@@ -1,4 +1,4 @@
-package design
+package dsl
 
 import "fmt"
 import . "github.com/raphael/goa/design"
@@ -21,11 +21,13 @@ import . "github.com/raphael/goa/design"
 //		Attribute("href")
 //	})
 // })
-func MediaType(identifier string, dsl func()) {
-	mt := MediaTypeDefinition{Name: name}
-	if ok := executeDSL(dsl, &mt); ok {
-		Design.MediaTypes = append(Design.MediaTypes, &mt)
+func MediaType(identifier string, dsl func()) *MediaTypeDefinition {
+	mt := &MediaTypeDefinition{Identifier: identifier}
+	if ok := executeDSL(dsl, mt); ok {
+		Design.MediaTypes = append(Design.MediaTypes, mt)
 	}
+
+	return mt
 }
 
 // View adds a new view to the media type.
@@ -62,11 +64,14 @@ func Link(name string, args ...interface{}) {
 	}
 }
 
+// FIXME
+//
 // CollectionOf creates a collection media type from its element media type.
 // A collection media type represents the content of responses that return a
 // collection of resources such as "index" actions.
-func CollectionOf(m *MediaTypeDefinition) *MediaTypeDefinition {
-	col := *m
-	col.isCollection = true
-	return &col
-}
+//
+// func CollectionOf(m *MediaTypeDefinition) *MediaTypeDefinition {
+// 	col := *m
+// 	col.IsCollection = true
+// 	return &col
+// }

--- a/design/dsl/resource.go
+++ b/design/dsl/resource.go
@@ -5,14 +5,14 @@ import . "github.com/raphael/goa/design"
 // Resource defines a resource DSL.
 //
 // Resource("bottle", func() {
-//      Description("A wine bottle") // Resource description
-// 	MediaType(BottleMediaType)   // Resource actions default media type
-// 	Prefix("/bottles")           // Resource actions path prefix if not ""
-//      Parent("account")            // Name of parent resource if any
-// 	CanonicalAction("show")      // Action that returns canonical representation
-// 	Trait("Authenticated")       // Included trait if any, can appear more than once
-// 	Action("show", func() {      // Action definition, can appear more than once
-//        // ... Action DSL
+//	Description("A wine bottle")		// Resource description
+// 	ResourceMediaType(BottleMediaType)  // Resource actions default media type
+// 	Prefix("/bottles")           		// Resource actions path prefix if not ""
+//	Parent("account")            		// Name of parent resource if any
+// 	CanonicalAction("show")      		// Action that returns canonical representation
+// 	Trait("Authenticated")       		// Included trait if any, can appear more than once
+// 	Action("show", func() {      		// Action definition, can appear more than once
+//		// ... Action DSL
 // 	})
 // })
 func Resource(name string, dsl func()) {
@@ -27,11 +27,10 @@ func Resource(name string, dsl func()) {
 	}
 }
 
-// MediaType sets the resource media type
-func MediaType(m *MediaTypeDefinition) {
+// ResourceMediaType sets the resource media type
+func ResourceMediaType(m *MediaTypeDefinition) {
 	if r, ok := ctxStack.current().(*ResourceDefinition); ok {
 		r.MediaType = m
-		m.Resource = r
 	} else if r, ok := responseDefinition(); ok {
 		r.MediaType = m
 	}
@@ -41,14 +40,14 @@ func MediaType(m *MediaTypeDefinition) {
 // The parent resource is used to compute the path to the resource actions.
 func Parent(p string) {
 	if r, ok := resourceDefinition(); ok {
-		r.Parent = p
+		r.ParentName = p
 	}
 }
 
 // Prefix sets the resource path prefix
 func Prefix(p string) {
 	if r, ok := resourceDefinition(); ok {
-		r.Prefix = p
+		r.BasePath = p
 	}
 }
 

--- a/design/dsl/runner.go
+++ b/design/dsl/runner.go
@@ -96,8 +96,8 @@ func reportErrors() {
 
 // actionDefinition returns true and current context if it is an ActionDefinition,
 // nil and false otherwise.
-func actionDefinition() (*design.ActionDefinition, bool) {
-	a, ok := ctxStack.current().(*design.ActionDefinition)
+func actionDefinition() (*ActionDefinition, bool) {
+	a, ok := ctxStack.current().(*ActionDefinition)
 	if !ok {
 		incompatibleDsl(caller())
 	}
@@ -128,6 +128,16 @@ func attributeDefinition() (*AttributeDefinition, bool) {
 // nil and false otherwise.
 func resourceDefinition() (*ResourceDefinition, bool) {
 	r, ok := ctxStack.current().(*ResourceDefinition)
+	if !ok {
+		incompatibleDsl(caller())
+	}
+	return r, ok
+}
+
+// mediaTypeDefinition returns true and current context if it is a MediaTypeDefinition,
+// nil and false otherwise.
+func mediaTypeDefinition() (*MediaTypeDefinition, bool) {
+	r, ok := ctxStack.current().(*MediaTypeDefinition)
 	if !ok {
 		incompatibleDsl(caller())
 	}

--- a/tools/goa/validation.go
+++ b/tools/goa/validation.go
@@ -13,7 +13,8 @@ var enumValidationTemplateC *template.Template
 // Generate enum validation code.
 func EnumValidationCode(values []interface{}) (string, error) {
 	if enumValidationTemplateC == nil {
-		enumValidationTemplateC, err := template.New("enum validation").Funcs(funcMap).Parse(enumValidationTemplate)
+		var err error
+		enumValidationTemplateC, err = template.New("enum validation").Funcs(funcMap).Parse(enumValidationTemplate)
 		if err != nil {
 			return "", fmt.Errorf("failed to instantiate enum validation template: %s", err)
 		}

--- a/tools/goa/validations.go
+++ b/tools/goa/validations.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+type Validation func(name string, val interface{}) error
+
 // validateRequired checks whether given value is the zero value
 func validateRequired(object, field string, val interface{}, zero interface{}) error {
 	if val == zero {
@@ -37,7 +39,7 @@ var ipv4Regex = regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`)
 // - "mac": IEEE 802 MAC-48, EUI-48 or EUI-64 MAC address value
 // - "cidr": RFC4632 and RFC4291 CIDR notation IP address value
 // - "regexp": Regular expression syntax accepted by RE2
-func validateFormat(f string) error {
+func validateFormat(f string) Validation {
 	return func(name string, val interface{}) error {
 		if val == nil {
 			return nil


### PR DESCRIPTION
It also involves some semantics change, which may be incorrect and need further discussion. Problems found:
 * Resource's MediaType which is conflict with MediaType
 * ResponseDefinition doesn't have an `initialize` func
 * In the example `BaseParams` take an array of `Attribute` as arguments, while `Attribute` doesn't return `AttributeDefinition`; instead, it expects to add the `AttributeDefinition` to the context itself.

I am still debating whether we should convert Praxis json to what goa can read/use. Though, I am submitting this quick patch in case that we choose the other route.