### PR TITLE
Report syntax errors before validation errors

### DIFF
--- a/design/dsl/runner.go
+++ b/design/dsl/runner.go
@@ -60,6 +60,10 @@ func RunDSL() error {
 	for _, r := range Design.Resources {
 		executeDSL(r.DSL, r)
 	}
+	// Don't attempt to validate syntactically incorrect DSL
+	if Errors != nil {
+		return Errors
+	}
 
 	// Validate DSL
 	if err := Design.Validate(); err != nil {


### PR DESCRIPTION
So that validation errors don't hide them.