### PR TITLE
Always generate the payload type

### DIFF
--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -178,10 +178,10 @@ func (w *ContextsWriter) Execute(data *ContextTemplateData) error {
 		return err
 	}
 	if data.Payload != nil {
+		if err := w.PayloadTmpl.Execute(w, data); err != nil {
+			return err
+		}
 		if _, ok := data.Payload.Type.(design.Object); ok {
-			if err := w.PayloadTmpl.Execute(w, data); err != nil {
-				return err
-			}
 			if err := w.NewPayloadTmpl.Execute(w, data); err != nil {
 				return err
 			}


### PR DESCRIPTION
Even if it's not an object.