### PR TITLE
Fix newline breaks after param validation

### DIFF
--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -378,7 +378,8 @@ func New{{.Name}}(c *goa.Context) (*{{.Name}}, error) {
 {{else}}	if ok {
 {{end}}{{template "Coerce" (newCoerceData $name $att (printf "ctx.%s" (goify $name true)) 2)}}{{if $ctx.MustSetHas $name}}		ctx.Has{{goify $name true}} = true
 {{end}}	}
-{{validationChecker $att $name $name}}{{end}}{{end}}{{/* if .Params */}}{{if .Payload}}	p, err := New{{gotypename .Payload 0}}(c.Payload())
+{{$validation := validationChecker $att $name $name}}{{if $validation}}{{$validation}}
+{{end}}{{end}}{{end}}{{/* if .Params */}}{{if .Payload}}	p, err := New{{gotypename .Payload 0}}(c.Payload())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
in context factory code