### PR TITLE
respond_500_to_panic

### DIFF
--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -219,9 +219,9 @@ func main() {
 	api := goa.New("{{.Name}}")
 
 	// Setup middleware
-	api.Use(goa.Recover())
 	api.Use(goa.RequestID())
 	api.Use(goa.LogRequest())
+	api.Use(goa.Recover())
 
 {{range $name, $res := .Resources}}	// Mount "{{$res.Name}}" controller
 	{{$tmp := tempvar}}{{$tmp}} := New{{goify $res.Name true}}Controller()

--- a/middleware.go
+++ b/middleware.go
@@ -162,41 +162,44 @@ func Recover() Middleware {
 		return func(ctx *Context) (err error) {
 			defer func() {
 				if r := recover(); r != nil {
-					switch x := r.(type) {
-					case string:
-						err = fmt.Errorf("panic: %s", x)
-					case error:
-						err = x
-					default:
-						err = errors.New("unknown panic")
-					}
-					const size = 64 << 10 // 64KB
-					buf := make([]byte, size)
-					buf = buf[:runtime.Stack(buf, false)]
-					lines := strings.Split(string(buf), "\n")
-					stack := lines[3:]
-					status := http.StatusInternalServerError
-					var message string
-					if ctx != nil && ctx.Logger != nil {
-						reqID := ctx.Value(ReqIDKey)
-						if reqID != nil {
-							message = fmt.Sprintf(
-								"%s\nRefer to the following token when contacting support: %s",
-								http.StatusText(status),
-								reqID)
+					if ctx != nil {
+						switch x := r.(type) {
+						case string:
+							err = fmt.Errorf("panic: %s", x)
+						case error:
+							err = x
+						default:
+							err = errors.New("unknown panic")
 						}
-						ctx.Logger.Error("panic", "err", err, "stack", stack)
-					}
+						const size = 64 << 10 // 64KB
+						buf := make([]byte, size)
+						buf = buf[:runtime.Stack(buf, false)]
+						lines := strings.Split(string(buf), "\n")
+						stack := lines[3:]
+						status := http.StatusInternalServerError
+						var message string
+						if ctx.Logger != nil {
+							reqID := ctx.Value(ReqIDKey)
+							if reqID != nil {
+								message = fmt.Sprintf(
+									"%s\nRefer to the following token when contacting support: %s",
+									http.StatusText(status),
+									reqID)
+							}
+							ctx.Logger.Error("panic", "err", err, "stack", stack)
+						}
 
-					// note we must respond or else a 500 with "unhandled request" is the
-					// default response.
-					if message == "" {
-						// without the request id (from middleware) we can only return the
-						// full error message for reference purposes. it is unlikely to make
-						// sense to the caller unless they understand the source code.
-						message = err.Error()
+						// note we must respond or else a 500 with "unhandled request" is the
+						// default response.
+						if message == "" {
+							// without the logger and/or request id (from middleware) we can
+							// only return the full error message for reference purposes. it
+							// is unlikely to make sense to the caller unless they understand
+							// the source code.
+							message = err.Error()
+						}
+						ctx.Respond(status, []byte(message))
 					}
-					ctx.Respond(status, []byte(message))
 				}
 			}()
 			return h(ctx)


### PR DESCRIPTION
respond 500 on recover instead of falling through to "unhandled request"
change generated middleware to log response after recover
