### PR TITLE
Client gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 examples/cellar/cellar
+examples/cellar/client/cellar-cli/cellar-cli
 **/*.coverprofile
 goagen/goagen
 **/autogen

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -428,6 +428,13 @@ func main() {
 	app.Flag("dump", "Dump HTTP request and response.").BoolVar(&c.Dump)
 	app.Flag("pp", "Pretty print response body").BoolVar(&PrettyPrint)
 	commands := RegisterCommands(app)
+	// Make "client-cli <action> [<resource>] --help" equivalent to
+	// "client-cli help <action> [<resource>]"
+	if os.Args[len(os.Args) - 1] == "--help" {
+		args := append([]string{os.Args[0]}, "help")
+		args = append(args, os.Args[1:]...)
+		os.Args = args
+	}
 	cmdName, err := app.Parse(os.Args[1:])
 	if err != nil {
 		kingpin.Fatalf(err.Error())
@@ -440,6 +447,7 @@ func main() {
 	if err != nil {
 		kingpin.Fatalf("request failed: %s", err)
 	}
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		kingpin.Fatalf("failed to read body: %s", err)
@@ -451,7 +459,7 @@ func main() {
 			sbody = ": " + string(body)
 		}
 		fmt.Printf("error: %d%s", resp.StatusCode, sbody)
-	} else if len(body) > 0 {
+	} else if !c.Dump && len(body) > 0 {
 		var out string
 		if PrettyPrint {
 			var jbody interface{}


### PR DESCRIPTION
Client generation fixes and improvements.
* Properly close response body io reader (thanks @on99).
* Properly handle `--help` flag.
* Prevent double dumping of response body with `--dump`.