### PR TITLE
Add Metadata

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -69,7 +69,8 @@ type (
 		MediaTypes map[string]*MediaTypeDefinition
 		// dsl contains the DSL used to create this definition if any.
 		DSL func()
-
+		// metadata is a list of key/value pairs
+		Metadata MetadataDefinition
 		// rand is the random generator used to generate examples.
 		rand *RandomGenerator
 	}
@@ -132,6 +133,8 @@ type (
 		Headers *AttributeDefinition
 		// dsl contains the DSL used to create this definition if any.
 		DSL func()
+		// metadata is a list of key/value pairs
+		Metadata MetadataDefinition
 	}
 
 	// ResponseDefinition defines a HTTP response status and optional validation rules.
@@ -148,6 +151,8 @@ type (
 		Headers *AttributeDefinition
 		// Parent action or resource
 		Parent DSLDefinition
+		// Metadata is a list of key/value pairs
+		Metadata MetadataDefinition
 	}
 
 	// ResponseTemplateDefinition defines a response template.
@@ -187,6 +192,8 @@ type (
 		Payload *UserTypeDefinition
 		// Request headers that need to be made available to action
 		Headers *AttributeDefinition
+		// Metadata is a list of key/value pairs
+		Metadata MetadataDefinition
 	}
 
 	// AttributeDefinition defines a JSON object member with optional description, default
@@ -200,11 +207,15 @@ type (
 		Description string
 		// Optional validation functions
 		Validations []ValidationDefinition
+		// Metadata is a list of key/value pairs
+		Metadata MetadataDefinition
 		// Optional member default value
 		DefaultValue interface{}
 		// Optional view used to render Attribute (only applies to media type attributes).
 		View string
 	}
+	// MetadataDefinition is a set of key/value pairs
+	MetadataDefinition map[string]string
 
 	// LinkDefinition defines a media type link, it specifies a URL to a related resource.
 	LinkDefinition struct {
@@ -695,6 +706,7 @@ func (a *AttributeDefinition) Dup() *AttributeDefinition {
 		Type:         dupType,
 		Description:  a.Description,
 		Validations:  valDup,
+		Metadata:     a.Metadata,
 		DefaultValue: a.DefaultValue,
 	}
 	return &dup

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/zach-klippenstein/goregen"
+	regen "github.com/zach-klippenstein/goregen"
 )
 
 var (

--- a/design/dsl/metadata.go
+++ b/design/dsl/metadata.go
@@ -1,0 +1,53 @@
+package dsl
+
+// Metadata is a key/value pair that can be assigned
+// to an object.  The value is expected be a JSON string, but is
+// not currently validated as such.
+// Metadata is not used in standard generation but may be
+// used by user-defined generators.
+// Usage:
+//	 Metadata("creator", `{"name":"goagen"}`)
+func Metadata(name string, value string) {
+	if at, ok := attributeDefinition(false); ok {
+		if at.Metadata == nil {
+			at.Metadata = make(map[string]string)
+		}
+		at.Metadata[name] = value
+		return
+	}
+	if mt, ok := mediaTypeDefinition(false); ok {
+		if mt.Metadata == nil {
+			mt.Metadata = make(map[string]string)
+		}
+		mt.Metadata[name] = value
+		return
+	}
+	if act, ok := actionDefinition(false); ok {
+		if act.Metadata == nil {
+			act.Metadata = make(map[string]string)
+		}
+		act.Metadata[name] = value
+		return
+	}
+	if res, ok := resourceDefinition(false); ok {
+		if res.Metadata == nil {
+			res.Metadata = make(map[string]string)
+		}
+		res.Metadata[name] = value
+		return
+	}
+	if rd, ok := responseDefinition(false); ok {
+		if rd.Metadata == nil {
+			rd.Metadata = make(map[string]string)
+		}
+		rd.Metadata[name] = value
+		return
+	}
+	if api, ok := apiDefinition(true); ok {
+		if api.Metadata == nil {
+			api.Metadata = make(map[string]string)
+		}
+		api.Metadata[name] = value
+		return
+	}
+}


### PR DESCRIPTION
Added Metadata to many of the base DSL types to allow for key/value pairs to be attached to most of the nodes on the DSL tree.

UseCase: In custom generators I need the ability to annotate things that aren't strictly DSL related.