### PR TITLE
Handle recursive definitions

### DIFF
--- a/design/dsl/media_type.go
+++ b/design/dsl/media_type.go
@@ -5,7 +5,6 @@ import (
 	"mime"
 	"strings"
 
-	"bitbucket.org/pkg/inflect"
 	"github.com/raphael/goa/design"
 )
 
@@ -96,10 +95,21 @@ func MediaType(identifier string, dsl func()) *design.MediaTypeDefinition {
 		identifier = mime.FormatMediaType(identifier, params)
 		// Concoct a Go type name from the identifier, should it be possible to set it in the DSL?
 		// pros: control the type name generated, cons: not needed in DSL, adds one more thing to worry about
-		elems := strings.Split(identifier, ".")
-		elems = strings.Split(elems[len(elems)-1], "/")
-		elems = strings.Split(elems[0], "+")
-		typeName := inflect.Camelize(elems[0])
+		lastPart := identifier
+		lastPartIndex := strings.LastIndex(identifier, "/")
+		if lastPartIndex > -1 {
+			lastPart = identifier[lastPartIndex+1:]
+		}
+		plusIndex := strings.Index(lastPart, "+")
+		if plusIndex > 0 {
+			lastPart = lastPart[:plusIndex]
+		}
+		lastPart = strings.TrimPrefix(lastPart, "vnd.")
+		elems := strings.Split(lastPart, ".")
+		for i, e := range elems {
+			elems[i] = strings.Title(e)
+		}
+		typeName := strings.Join(elems, "")
 		if typeName == "" {
 			mediaTypeCount++
 			typeName = fmt.Sprintf("MediaType%d", mediaTypeCount)

--- a/design/types.go
+++ b/design/types.go
@@ -24,6 +24,8 @@ type (
 		Kind() Kind
 		// Name returns the type name.
 		Name() string
+		// IsPrimitive returns true if the underlying type is one of the primitive types.
+		IsPrimitive() bool
 		// IsObject returns true if the underlying type is an object, a user type which
 		// is an object or a media type whose type is an object.
 		IsObject() bool
@@ -164,6 +166,9 @@ func (p Primitive) Name() string {
 	}
 }
 
+// IsPrimitive returns true.
+func (p Primitive) IsPrimitive() bool { return true }
+
 // IsObject returns false.
 func (p Primitive) IsObject() bool { return false }
 
@@ -261,6 +266,9 @@ func (a *Array) Name() string {
 	return "array"
 }
 
+// IsPrimitive returns false.
+func (a *Array) IsPrimitive() bool { return false }
+
 // IsObject returns false.
 func (a *Array) IsObject() bool { return false }
 
@@ -305,6 +313,9 @@ func (o Object) Kind() Kind { return ObjectKind }
 
 // Name returns the type name.
 func (o Object) Name() string { return "object" }
+
+// IsPrimitive returns false.
+func (o Object) IsPrimitive() bool { return false }
 
 // IsObject returns true.
 func (o Object) IsObject() bool { return true }
@@ -360,6 +371,9 @@ func (h *Hash) Kind() Kind { return HashKind }
 
 // Name returns the type name.
 func (h *Hash) Name() string { return "hash" }
+
+// IsPrimitive returns false.
+func (h *Hash) IsPrimitive() bool { return false }
 
 // IsObject returns false.
 func (h *Hash) IsObject() bool { return false }
@@ -440,6 +454,9 @@ func (u *UserTypeDefinition) Kind() Kind { return UserTypeKind }
 
 // Name returns the JSON type name.
 func (u *UserTypeDefinition) Name() string { return u.Type.Name() }
+
+// IsPrimitive calls IsPrimitive on the user type underlying data type.
+func (u *UserTypeDefinition) IsPrimitive() bool { return u.Type.IsPrimitive() }
 
 // IsObject calls IsObject on the user type underlying data type.
 func (u *UserTypeDefinition) IsObject() bool { return u.Type.IsObject() }

--- a/examples/cellar/app/contexts.go
+++ b/examples/cellar/app/contexts.go
@@ -144,7 +144,7 @@ func (ctx *ShowAccountContext) OK(resp *Account, view AccountViewEnum) error {
 	if err != nil {
 		return fmt.Errorf("invalid response: %s", err)
 	}
-	ctx.Header().Set("Content-Type", "application/vnd.goa.example.account+json; charset=utf-8")
+	ctx.Header().Set("Content-Type", "application/vnd.account+json; charset=utf-8")
 	return ctx.JSON(200, r)
 }
 
@@ -518,7 +518,7 @@ func (ctx *ListBottleContext) OK(resp BottleCollection, view BottleCollectionVie
 	if err != nil {
 		return fmt.Errorf("invalid response: %s", err)
 	}
-	ctx.Header().Set("Content-Type", "application/vnd.goa.example.bottle+json; type=collection; charset=utf-8")
+	ctx.Header().Set("Content-Type", "application/vnd.bottle+json; type=collection; charset=utf-8")
 	return ctx.JSON(200, r)
 }
 
@@ -654,7 +654,7 @@ func (ctx *ShowBottleContext) OK(resp *Bottle, view BottleViewEnum) error {
 	if err != nil {
 		return fmt.Errorf("invalid response: %s", err)
 	}
-	ctx.Header().Set("Content-Type", "application/vnd.goa.example.bottle+json; charset=utf-8")
+	ctx.Header().Set("Content-Type", "application/vnd.bottle+json; charset=utf-8")
 	return ctx.JSON(200, r)
 }
 

--- a/examples/cellar/app/contexts.go
+++ b/examples/cellar/app/contexts.go
@@ -47,11 +47,16 @@ type CreateAccountPayload struct {
 
 // NewCreateAccountPayload instantiates a CreateAccountPayload from a raw request body.
 // It validates each field and returns an error if any validation fails.
-func NewCreateAccountPayload(raw interface{}) (*CreateAccountPayload, error) {
-	var err error
-	var p *CreateAccountPayload
-	if val, ok := raw.(map[string]interface{}); ok {
-		p = new(CreateAccountPayload)
+func NewCreateAccountPayload(raw interface{}) (p *CreateAccountPayload, err error) {
+	p, err = UnmarshalCreateAccountPayload(raw, err)
+	return
+}
+
+// UnmarshalCreateAccountPayload unmarshals and validates a raw interface{} into an instance of CreateAccountPayload
+func UnmarshalCreateAccountPayload(source interface{}, inErr error) (target *CreateAccountPayload, err error) {
+	err = inErr
+	if val, ok := source.(map[string]interface{}); ok {
+		target = new(CreateAccountPayload)
 		if v, ok := val["name"]; ok {
 			var tmp1 string
 			if val, ok := v.(string); ok {
@@ -59,14 +64,14 @@ func NewCreateAccountPayload(raw interface{}) (*CreateAccountPayload, error) {
 			} else {
 				err = goa.InvalidAttributeTypeError(`payload.Name`, v, "string", err)
 			}
-			p.Name = tmp1
+			target.Name = tmp1
 		} else {
 			err = goa.MissingAttributeError(`payload`, "name", err)
 		}
 	} else {
-		err = goa.InvalidAttributeTypeError(`payload`, raw, "dictionary", err)
+		err = goa.InvalidAttributeTypeError(`payload`, source, "dictionary", err)
 	}
-	return p, err
+	return
 }
 
 // Created sends a HTTP response with status code 201.
@@ -179,11 +184,16 @@ type UpdateAccountPayload struct {
 
 // NewUpdateAccountPayload instantiates a UpdateAccountPayload from a raw request body.
 // It validates each field and returns an error if any validation fails.
-func NewUpdateAccountPayload(raw interface{}) (*UpdateAccountPayload, error) {
-	var err error
-	var p *UpdateAccountPayload
-	if val, ok := raw.(map[string]interface{}); ok {
-		p = new(UpdateAccountPayload)
+func NewUpdateAccountPayload(raw interface{}) (p *UpdateAccountPayload, err error) {
+	p, err = UnmarshalUpdateAccountPayload(raw, err)
+	return
+}
+
+// UnmarshalUpdateAccountPayload unmarshals and validates a raw interface{} into an instance of UpdateAccountPayload
+func UnmarshalUpdateAccountPayload(source interface{}, inErr error) (target *UpdateAccountPayload, err error) {
+	err = inErr
+	if val, ok := source.(map[string]interface{}); ok {
+		target = new(UpdateAccountPayload)
 		if v, ok := val["name"]; ok {
 			var tmp2 string
 			if val, ok := v.(string); ok {
@@ -191,14 +201,14 @@ func NewUpdateAccountPayload(raw interface{}) (*UpdateAccountPayload, error) {
 			} else {
 				err = goa.InvalidAttributeTypeError(`payload.Name`, v, "string", err)
 			}
-			p.Name = tmp2
+			target.Name = tmp2
 		} else {
 			err = goa.MissingAttributeError(`payload`, "name", err)
 		}
 	} else {
-		err = goa.InvalidAttributeTypeError(`payload`, raw, "dictionary", err)
+		err = goa.InvalidAttributeTypeError(`payload`, source, "dictionary", err)
 	}
-	return p, err
+	return
 }
 
 // NoContent sends a HTTP response with status code 204.
@@ -254,11 +264,16 @@ type CreateBottlePayload struct {
 
 // NewCreateBottlePayload instantiates a CreateBottlePayload from a raw request body.
 // It validates each field and returns an error if any validation fails.
-func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
-	var err error
-	var p *CreateBottlePayload
-	if val, ok := raw.(map[string]interface{}); ok {
-		p = new(CreateBottlePayload)
+func NewCreateBottlePayload(raw interface{}) (p *CreateBottlePayload, err error) {
+	p, err = UnmarshalCreateBottlePayload(raw, err)
+	return
+}
+
+// UnmarshalCreateBottlePayload unmarshals and validates a raw interface{} into an instance of CreateBottlePayload
+func UnmarshalCreateBottlePayload(source interface{}, inErr error) (target *CreateBottlePayload, err error) {
+	err = inErr
+	if val, ok := source.(map[string]interface{}); ok {
+		target = new(CreateBottlePayload)
 		if v, ok := val["color"]; ok {
 			var tmp3 string
 			if val, ok := v.(string); ok {
@@ -273,7 +288,7 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 					}
 				}
 			}
-			p.Color = tmp3
+			target.Color = tmp3
 		} else {
 			err = goa.MissingAttributeError(`payload`, "color", err)
 		}
@@ -289,7 +304,7 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Country`, tmp4, 2, true, err)
 				}
 			}
-			p.Country = tmp4
+			target.Country = tmp4
 		}
 		if v, ok := val["name"]; ok {
 			var tmp5 string
@@ -303,7 +318,7 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Name`, tmp5, 2, true, err)
 				}
 			}
-			p.Name = tmp5
+			target.Name = tmp5
 		} else {
 			err = goa.MissingAttributeError(`payload`, "name", err)
 		}
@@ -314,7 +329,7 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 			} else {
 				err = goa.InvalidAttributeTypeError(`payload.Region`, v, "string", err)
 			}
-			p.Region = tmp6
+			target.Region = tmp6
 		}
 		if v, ok := val["review"]; ok {
 			var tmp7 string
@@ -331,7 +346,7 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Review`, tmp7, 300, false, err)
 				}
 			}
-			p.Review = tmp7
+			target.Review = tmp7
 		}
 		if v, ok := val["sweetness"]; ok {
 			var tmp8 int
@@ -348,7 +363,7 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 					err = goa.InvalidRangeError(`payload.Sweetness`, tmp8, 5, false, err)
 				}
 			}
-			p.Sweetness = tmp8
+			target.Sweetness = tmp8
 		}
 		if v, ok := val["varietal"]; ok {
 			var tmp9 string
@@ -362,7 +377,7 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Varietal`, tmp9, 4, true, err)
 				}
 			}
-			p.Varietal = tmp9
+			target.Varietal = tmp9
 		} else {
 			err = goa.MissingAttributeError(`payload`, "varietal", err)
 		}
@@ -378,7 +393,7 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Vineyard`, tmp10, 2, true, err)
 				}
 			}
-			p.Vineyard = tmp10
+			target.Vineyard = tmp10
 		} else {
 			err = goa.MissingAttributeError(`payload`, "vineyard", err)
 		}
@@ -397,14 +412,14 @@ func NewCreateBottlePayload(raw interface{}) (*CreateBottlePayload, error) {
 					err = goa.InvalidRangeError(`payload.Vintage`, tmp11, 2020, false, err)
 				}
 			}
-			p.Vintage = tmp11
+			target.Vintage = tmp11
 		} else {
 			err = goa.MissingAttributeError(`payload`, "vintage", err)
 		}
 	} else {
-		err = goa.InvalidAttributeTypeError(`payload`, raw, "dictionary", err)
+		err = goa.InvalidAttributeTypeError(`payload`, source, "dictionary", err)
 	}
-	return p, err
+	return
 }
 
 // Created sends a HTTP response with status code 201.
@@ -552,11 +567,16 @@ type RateBottlePayload struct {
 
 // NewRateBottlePayload instantiates a RateBottlePayload from a raw request body.
 // It validates each field and returns an error if any validation fails.
-func NewRateBottlePayload(raw interface{}) (*RateBottlePayload, error) {
-	var err error
-	var p *RateBottlePayload
-	if val, ok := raw.(map[string]interface{}); ok {
-		p = new(RateBottlePayload)
+func NewRateBottlePayload(raw interface{}) (p *RateBottlePayload, err error) {
+	p, err = UnmarshalRateBottlePayload(raw, err)
+	return
+}
+
+// UnmarshalRateBottlePayload unmarshals and validates a raw interface{} into an instance of RateBottlePayload
+func UnmarshalRateBottlePayload(source interface{}, inErr error) (target *RateBottlePayload, err error) {
+	err = inErr
+	if val, ok := source.(map[string]interface{}); ok {
+		target = new(RateBottlePayload)
 		if v, ok := val["rating"]; ok {
 			var tmp12 int
 			if f, ok := v.(float64); ok {
@@ -572,14 +592,14 @@ func NewRateBottlePayload(raw interface{}) (*RateBottlePayload, error) {
 					err = goa.InvalidRangeError(`payload.Rating`, tmp12, 5, false, err)
 				}
 			}
-			p.Rating = tmp12
+			target.Rating = tmp12
 		} else {
 			err = goa.MissingAttributeError(`payload`, "rating", err)
 		}
 	} else {
-		err = goa.InvalidAttributeTypeError(`payload`, raw, "dictionary", err)
+		err = goa.InvalidAttributeTypeError(`payload`, source, "dictionary", err)
 	}
-	return p, err
+	return
 }
 
 // NoContent sends a HTTP response with status code 204.
@@ -690,11 +710,16 @@ type UpdateBottlePayload struct {
 
 // NewUpdateBottlePayload instantiates a UpdateBottlePayload from a raw request body.
 // It validates each field and returns an error if any validation fails.
-func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
-	var err error
-	var p *UpdateBottlePayload
-	if val, ok := raw.(map[string]interface{}); ok {
-		p = new(UpdateBottlePayload)
+func NewUpdateBottlePayload(raw interface{}) (p *UpdateBottlePayload, err error) {
+	p, err = UnmarshalUpdateBottlePayload(raw, err)
+	return
+}
+
+// UnmarshalUpdateBottlePayload unmarshals and validates a raw interface{} into an instance of UpdateBottlePayload
+func UnmarshalUpdateBottlePayload(source interface{}, inErr error) (target *UpdateBottlePayload, err error) {
+	err = inErr
+	if val, ok := source.(map[string]interface{}); ok {
+		target = new(UpdateBottlePayload)
 		if v, ok := val["color"]; ok {
 			var tmp13 string
 			if val, ok := v.(string); ok {
@@ -709,7 +734,7 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 					}
 				}
 			}
-			p.Color = tmp13
+			target.Color = tmp13
 		}
 		if v, ok := val["country"]; ok {
 			var tmp14 string
@@ -723,7 +748,7 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Country`, tmp14, 2, true, err)
 				}
 			}
-			p.Country = tmp14
+			target.Country = tmp14
 		}
 		if v, ok := val["name"]; ok {
 			var tmp15 string
@@ -737,7 +762,7 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Name`, tmp15, 2, true, err)
 				}
 			}
-			p.Name = tmp15
+			target.Name = tmp15
 		}
 		if v, ok := val["region"]; ok {
 			var tmp16 string
@@ -746,7 +771,7 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 			} else {
 				err = goa.InvalidAttributeTypeError(`payload.Region`, v, "string", err)
 			}
-			p.Region = tmp16
+			target.Region = tmp16
 		}
 		if v, ok := val["review"]; ok {
 			var tmp17 string
@@ -763,7 +788,7 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Review`, tmp17, 300, false, err)
 				}
 			}
-			p.Review = tmp17
+			target.Review = tmp17
 		}
 		if v, ok := val["sweetness"]; ok {
 			var tmp18 int
@@ -780,7 +805,7 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 					err = goa.InvalidRangeError(`payload.Sweetness`, tmp18, 5, false, err)
 				}
 			}
-			p.Sweetness = tmp18
+			target.Sweetness = tmp18
 		}
 		if v, ok := val["varietal"]; ok {
 			var tmp19 string
@@ -794,7 +819,7 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Varietal`, tmp19, 4, true, err)
 				}
 			}
-			p.Varietal = tmp19
+			target.Varietal = tmp19
 		}
 		if v, ok := val["vineyard"]; ok {
 			var tmp20 string
@@ -808,7 +833,7 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 					err = goa.InvalidLengthError(`payload.Vineyard`, tmp20, 2, true, err)
 				}
 			}
-			p.Vineyard = tmp20
+			target.Vineyard = tmp20
 		}
 		if v, ok := val["vintage"]; ok {
 			var tmp21 int
@@ -825,12 +850,12 @@ func NewUpdateBottlePayload(raw interface{}) (*UpdateBottlePayload, error) {
 					err = goa.InvalidRangeError(`payload.Vintage`, tmp21, 2020, false, err)
 				}
 			}
-			p.Vintage = tmp21
+			target.Vintage = tmp21
 		}
 	} else {
-		err = goa.InvalidAttributeTypeError(`payload`, raw, "dictionary", err)
+		err = goa.InvalidAttributeTypeError(`payload`, source, "dictionary", err)
 	}
-	return p, err
+	return
 }
 
 // NoContent sends a HTTP response with status code 204.

--- a/examples/cellar/app/media_types.go
+++ b/examples/cellar/app/media_types.go
@@ -15,7 +15,7 @@ package app
 import "github.com/raphael/goa"
 
 // A tenant account
-// Identifier: application/vnd.goa.example.account+json
+// Identifier: application/vnd.account+json
 type Account struct {
 	// Date of creation
 	CreatedAt string
@@ -184,7 +184,7 @@ func UnmarshalAccount(source interface{}, inErr error) (target *Account, err err
 }
 
 // A bottle of wine
-// Identifier: application/vnd.goa.example.bottle+json
+// Identifier: application/vnd.bottle+json
 type Bottle struct {
 	// Account that owns bottle
 	Account *Account
@@ -681,7 +681,7 @@ func UnmarshalBottle(source interface{}, inErr error) (target *Bottle, err error
 }
 
 // BottleCollection media type
-// Identifier: application/vnd.goa.example.bottle+json; type=collection
+// Identifier: application/vnd.bottle+json; type=collection
 type BottleCollection []*Bottle
 
 // BottleCollection views

--- a/examples/cellar/app/media_types.go
+++ b/examples/cellar/app/media_types.go
@@ -43,110 +43,21 @@ const (
 // validations. Raw data is defined by data that the JSON unmarshaler would create when unmarshaling
 // into a variable of type interface{}. See https://golang.org/pkg/encoding/json/#Unmarshal for the
 // complete list of supported data types.
-func LoadAccount(raw interface{}) (*Account, error) {
-	var err error
-	var res *Account
-	if val, ok := raw.(map[string]interface{}); ok {
-		res = new(Account)
-		if v, ok := val["created_at"]; ok {
-			var tmp22 string
-			if val, ok := v.(string); ok {
-				tmp22 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.CreatedAt`, v, "string", err)
-			}
-			if err == nil {
-				if tmp22 != "" {
-					if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp22); err2 != nil {
-						err = goa.InvalidFormatError(`.CreatedAt`, tmp22, goa.FormatDateTime, err2, err)
-					}
-				}
-			}
-			res.CreatedAt = tmp22
-		}
-		if v, ok := val["created_by"]; ok {
-			var tmp23 string
-			if val, ok := v.(string); ok {
-				tmp23 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.CreatedBy`, v, "string", err)
-			}
-			if err == nil {
-				if tmp23 != "" {
-					if err2 := goa.ValidateFormat(goa.FormatEmail, tmp23); err2 != nil {
-						err = goa.InvalidFormatError(`.CreatedBy`, tmp23, goa.FormatEmail, err2, err)
-					}
-				}
-			}
-			res.CreatedBy = tmp23
-		}
-		if v, ok := val["href"]; ok {
-			var tmp24 string
-			if val, ok := v.(string); ok {
-				tmp24 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Href`, v, "string", err)
-			}
-			res.Href = tmp24
-		}
-		if v, ok := val["id"]; ok {
-			var tmp25 int
-			if f, ok := v.(float64); ok {
-				tmp25 = int(f)
-			} else {
-				err = goa.InvalidAttributeTypeError(`.ID`, v, "int", err)
-			}
-			res.ID = tmp25
-		}
-		if v, ok := val["name"]; ok {
-			var tmp26 string
-			if val, ok := v.(string); ok {
-				tmp26 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Name`, v, "string", err)
-			}
-			res.Name = tmp26
-		}
-	} else {
-		err = goa.InvalidAttributeTypeError(``, raw, "dictionary", err)
-	}
-	return res, err
+func LoadAccount(raw interface{}) (res *Account, err error) {
+	res, err = UnmarshalAccount(raw, err)
+	return
 }
 
 // Dump produces raw data from an instance of Account running all the
 // validations. See LoadAccount for the definition of raw data.
-func (mt *Account) Dump(view AccountViewEnum) (map[string]interface{}, error) {
-	var err error
-	var res map[string]interface{}
+func (mt *Account) Dump(view AccountViewEnum) (res map[string]interface{}, err error) {
 	if view == AccountDefaultView {
-		if mt.CreatedAt != "" {
-			if err2 := goa.ValidateFormat(goa.FormatDateTime, mt.CreatedAt); err2 != nil {
-				err = goa.InvalidFormatError(`default view.created_at`, mt.CreatedAt, goa.FormatDateTime, err2, err)
-			}
-		}
-		if mt.CreatedBy != "" {
-			if err2 := goa.ValidateFormat(goa.FormatEmail, mt.CreatedBy); err2 != nil {
-				err = goa.InvalidFormatError(`default view.created_by`, mt.CreatedBy, goa.FormatEmail, err2, err)
-			}
-		}
-		tmp27 := map[string]interface{}{
-			"created_at": mt.CreatedAt,
-			"created_by": mt.CreatedBy,
-			"href":       mt.Href,
-			"id":         mt.ID,
-			"name":       mt.Name,
-		}
-		res = tmp27
+		res, err = MarshalAccount(mt, err)
 	}
 	if view == AccountLinkView {
-		tmp28 := map[string]interface{}{
-			"href": mt.Href,
-			"id":   mt.ID,
-			"name": mt.Name,
-		}
-		res = tmp28
+		res, err = MarshalAccountLink(mt, err)
 	}
-	return res, err
+	return
 }
 
 // Validate validates the media type instance.
@@ -160,6 +71,114 @@ func (mt *Account) Validate() (err error) {
 		if err2 := goa.ValidateFormat(goa.FormatEmail, mt.CreatedBy); err2 != nil {
 			err = goa.InvalidFormatError(`response.created_by`, mt.CreatedBy, goa.FormatEmail, err2, err)
 		}
+	}
+	return
+}
+
+// MarshalAccount validates and renders an instance of Account into a interface{}
+// using view "default".
+func MarshalAccount(source *Account, inErr error) (target map[string]interface{}, err error) {
+	err = inErr
+	if source.CreatedAt != "" {
+		if err2 := goa.ValidateFormat(goa.FormatDateTime, source.CreatedAt); err2 != nil {
+			err = goa.InvalidFormatError(`.created_at`, source.CreatedAt, goa.FormatDateTime, err2, err)
+		}
+	}
+	if source.CreatedBy != "" {
+		if err2 := goa.ValidateFormat(goa.FormatEmail, source.CreatedBy); err2 != nil {
+			err = goa.InvalidFormatError(`.created_by`, source.CreatedBy, goa.FormatEmail, err2, err)
+		}
+	}
+	tmp22 := map[string]interface{}{
+		"created_at": source.CreatedAt,
+		"created_by": source.CreatedBy,
+		"href":       source.Href,
+		"id":         source.ID,
+		"name":       source.Name,
+	}
+	target = tmp22
+	return
+}
+
+// MarshalAccountLink validates and renders an instance of Account into a interface{}
+// using view "link".
+func MarshalAccountLink(source *Account, inErr error) (target map[string]interface{}, err error) {
+	err = inErr
+	tmp23 := map[string]interface{}{
+		"href": source.Href,
+		"id":   source.ID,
+		"name": source.Name,
+	}
+	target = tmp23
+	return
+}
+
+// UnmarshalAccount unmarshals and validates a raw interface{} into an instance of Account
+func UnmarshalAccount(source interface{}, inErr error) (target *Account, err error) {
+	err = inErr
+	if val, ok := source.(map[string]interface{}); ok {
+		target = new(Account)
+		if v, ok := val["created_at"]; ok {
+			var tmp24 string
+			if val, ok := v.(string); ok {
+				tmp24 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.CreatedAt`, v, "string", err)
+			}
+			if err == nil {
+				if tmp24 != "" {
+					if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp24); err2 != nil {
+						err = goa.InvalidFormatError(`load.CreatedAt`, tmp24, goa.FormatDateTime, err2, err)
+					}
+				}
+			}
+			target.CreatedAt = tmp24
+		}
+		if v, ok := val["created_by"]; ok {
+			var tmp25 string
+			if val, ok := v.(string); ok {
+				tmp25 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.CreatedBy`, v, "string", err)
+			}
+			if err == nil {
+				if tmp25 != "" {
+					if err2 := goa.ValidateFormat(goa.FormatEmail, tmp25); err2 != nil {
+						err = goa.InvalidFormatError(`load.CreatedBy`, tmp25, goa.FormatEmail, err2, err)
+					}
+				}
+			}
+			target.CreatedBy = tmp25
+		}
+		if v, ok := val["href"]; ok {
+			var tmp26 string
+			if val, ok := v.(string); ok {
+				tmp26 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Href`, v, "string", err)
+			}
+			target.Href = tmp26
+		}
+		if v, ok := val["id"]; ok {
+			var tmp27 int
+			if f, ok := v.(float64); ok {
+				tmp27 = int(f)
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.ID`, v, "int", err)
+			}
+			target.ID = tmp27
+		}
+		if v, ok := val["name"]; ok {
+			var tmp28 string
+			if val, ok := v.(string); ok {
+				tmp28 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Name`, v, "string", err)
+			}
+			target.Name = tmp28
+		}
+	} else {
+		err = goa.InvalidAttributeTypeError(`load`, source, "dictionary", err)
 	}
 	return
 }
@@ -206,461 +225,24 @@ const (
 // validations. Raw data is defined by data that the JSON unmarshaler would create when unmarshaling
 // into a variable of type interface{}. See https://golang.org/pkg/encoding/json/#Unmarshal for the
 // complete list of supported data types.
-func LoadBottle(raw interface{}) (*Bottle, error) {
-	var err error
-	var res *Bottle
-	if val, ok := raw.(map[string]interface{}); ok {
-		res = new(Bottle)
-		if v, ok := val["account"]; ok {
-			var tmp29 *Account
-			if val, ok := v.(map[string]interface{}); ok {
-				tmp29 = new(Account)
-				if v, ok := val["created_at"]; ok {
-					var tmp30 string
-					if val, ok := v.(string); ok {
-						tmp30 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`.Account.CreatedAt`, v, "string", err)
-					}
-					if err == nil {
-						if tmp30 != "" {
-							if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp30); err2 != nil {
-								err = goa.InvalidFormatError(`.Account.CreatedAt`, tmp30, goa.FormatDateTime, err2, err)
-							}
-						}
-					}
-					tmp29.CreatedAt = tmp30
-				}
-				if v, ok := val["created_by"]; ok {
-					var tmp31 string
-					if val, ok := v.(string); ok {
-						tmp31 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`.Account.CreatedBy`, v, "string", err)
-					}
-					if err == nil {
-						if tmp31 != "" {
-							if err2 := goa.ValidateFormat(goa.FormatEmail, tmp31); err2 != nil {
-								err = goa.InvalidFormatError(`.Account.CreatedBy`, tmp31, goa.FormatEmail, err2, err)
-							}
-						}
-					}
-					tmp29.CreatedBy = tmp31
-				}
-				if v, ok := val["href"]; ok {
-					var tmp32 string
-					if val, ok := v.(string); ok {
-						tmp32 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`.Account.Href`, v, "string", err)
-					}
-					tmp29.Href = tmp32
-				}
-				if v, ok := val["id"]; ok {
-					var tmp33 int
-					if f, ok := v.(float64); ok {
-						tmp33 = int(f)
-					} else {
-						err = goa.InvalidAttributeTypeError(`.Account.ID`, v, "int", err)
-					}
-					tmp29.ID = tmp33
-				}
-				if v, ok := val["name"]; ok {
-					var tmp34 string
-					if val, ok := v.(string); ok {
-						tmp34 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`.Account.Name`, v, "string", err)
-					}
-					tmp29.Name = tmp34
-				}
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Account`, v, "dictionary", err)
-			}
-			res.Account = tmp29
-		}
-		if v, ok := val["color"]; ok {
-			var tmp35 string
-			if val, ok := v.(string); ok {
-				tmp35 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Color`, v, "string", err)
-			}
-			if err == nil {
-				if tmp35 != "" {
-					if !(tmp35 == "red" || tmp35 == "white" || tmp35 == "rose" || tmp35 == "yellow" || tmp35 == "sparkling") {
-						err = goa.InvalidEnumValueError(`.Color`, tmp35, []interface{}{"red", "white", "rose", "yellow", "sparkling"}, err)
-					}
-				}
-			}
-			res.Color = tmp35
-		}
-		if v, ok := val["country"]; ok {
-			var tmp36 string
-			if val, ok := v.(string); ok {
-				tmp36 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Country`, v, "string", err)
-			}
-			if err == nil {
-				if len(tmp36) < 2 {
-					err = goa.InvalidLengthError(`.Country`, tmp36, 2, true, err)
-				}
-			}
-			res.Country = tmp36
-		}
-		if v, ok := val["created_at"]; ok {
-			var tmp37 string
-			if val, ok := v.(string); ok {
-				tmp37 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.CreatedAt`, v, "string", err)
-			}
-			if err == nil {
-				if tmp37 != "" {
-					if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp37); err2 != nil {
-						err = goa.InvalidFormatError(`.CreatedAt`, tmp37, goa.FormatDateTime, err2, err)
-					}
-				}
-			}
-			res.CreatedAt = tmp37
-		}
-		if v, ok := val["href"]; ok {
-			var tmp38 string
-			if val, ok := v.(string); ok {
-				tmp38 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Href`, v, "string", err)
-			}
-			res.Href = tmp38
-		}
-		if v, ok := val["id"]; ok {
-			var tmp39 int
-			if f, ok := v.(float64); ok {
-				tmp39 = int(f)
-			} else {
-				err = goa.InvalidAttributeTypeError(`.ID`, v, "int", err)
-			}
-			res.ID = tmp39
-		}
-		if v, ok := val["name"]; ok {
-			var tmp40 string
-			if val, ok := v.(string); ok {
-				tmp40 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Name`, v, "string", err)
-			}
-			if err == nil {
-				if len(tmp40) < 2 {
-					err = goa.InvalidLengthError(`.Name`, tmp40, 2, true, err)
-				}
-			}
-			res.Name = tmp40
-		}
-		if v, ok := val["rating"]; ok {
-			var tmp41 int
-			if f, ok := v.(float64); ok {
-				tmp41 = int(f)
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Rating`, v, "int", err)
-			}
-			if err == nil {
-				if tmp41 < 1 {
-					err = goa.InvalidRangeError(`.Rating`, tmp41, 1, true, err)
-				}
-				if tmp41 > 5 {
-					err = goa.InvalidRangeError(`.Rating`, tmp41, 5, false, err)
-				}
-			}
-			res.Rating = tmp41
-		}
-		if v, ok := val["region"]; ok {
-			var tmp42 string
-			if val, ok := v.(string); ok {
-				tmp42 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Region`, v, "string", err)
-			}
-			res.Region = tmp42
-		}
-		if v, ok := val["review"]; ok {
-			var tmp43 string
-			if val, ok := v.(string); ok {
-				tmp43 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Review`, v, "string", err)
-			}
-			if err == nil {
-				if len(tmp43) < 10 {
-					err = goa.InvalidLengthError(`.Review`, tmp43, 10, true, err)
-				}
-				if len(tmp43) > 300 {
-					err = goa.InvalidLengthError(`.Review`, tmp43, 300, false, err)
-				}
-			}
-			res.Review = tmp43
-		}
-		if v, ok := val["sweetness"]; ok {
-			var tmp44 int
-			if f, ok := v.(float64); ok {
-				tmp44 = int(f)
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Sweetness`, v, "int", err)
-			}
-			if err == nil {
-				if tmp44 < 1 {
-					err = goa.InvalidRangeError(`.Sweetness`, tmp44, 1, true, err)
-				}
-				if tmp44 > 5 {
-					err = goa.InvalidRangeError(`.Sweetness`, tmp44, 5, false, err)
-				}
-			}
-			res.Sweetness = tmp44
-		}
-		if v, ok := val["updated_at"]; ok {
-			var tmp45 string
-			if val, ok := v.(string); ok {
-				tmp45 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.UpdatedAt`, v, "string", err)
-			}
-			if err == nil {
-				if tmp45 != "" {
-					if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp45); err2 != nil {
-						err = goa.InvalidFormatError(`.UpdatedAt`, tmp45, goa.FormatDateTime, err2, err)
-					}
-				}
-			}
-			res.UpdatedAt = tmp45
-		}
-		if v, ok := val["varietal"]; ok {
-			var tmp46 string
-			if val, ok := v.(string); ok {
-				tmp46 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Varietal`, v, "string", err)
-			}
-			if err == nil {
-				if len(tmp46) < 4 {
-					err = goa.InvalidLengthError(`.Varietal`, tmp46, 4, true, err)
-				}
-			}
-			res.Varietal = tmp46
-		}
-		if v, ok := val["vineyard"]; ok {
-			var tmp47 string
-			if val, ok := v.(string); ok {
-				tmp47 = val
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Vineyard`, v, "string", err)
-			}
-			if err == nil {
-				if len(tmp47) < 2 {
-					err = goa.InvalidLengthError(`.Vineyard`, tmp47, 2, true, err)
-				}
-			}
-			res.Vineyard = tmp47
-		}
-		if v, ok := val["vintage"]; ok {
-			var tmp48 int
-			if f, ok := v.(float64); ok {
-				tmp48 = int(f)
-			} else {
-				err = goa.InvalidAttributeTypeError(`.Vintage`, v, "int", err)
-			}
-			if err == nil {
-				if tmp48 < 1900 {
-					err = goa.InvalidRangeError(`.Vintage`, tmp48, 1900, true, err)
-				}
-				if tmp48 > 2020 {
-					err = goa.InvalidRangeError(`.Vintage`, tmp48, 2020, false, err)
-				}
-			}
-			res.Vintage = tmp48
-		}
-	} else {
-		err = goa.InvalidAttributeTypeError(``, raw, "dictionary", err)
-	}
-	return res, err
+func LoadBottle(raw interface{}) (res *Bottle, err error) {
+	res, err = UnmarshalBottle(raw, err)
+	return
 }
 
 // Dump produces raw data from an instance of Bottle running all the
 // validations. See LoadBottle for the definition of raw data.
-func (mt *Bottle) Dump(view BottleViewEnum) (map[string]interface{}, error) {
-	var err error
-	var res map[string]interface{}
+func (mt *Bottle) Dump(view BottleViewEnum) (res map[string]interface{}, err error) {
 	if view == BottleDefaultView {
-		if len(mt.Name) < 2 {
-			err = goa.InvalidLengthError(`default view.name`, mt.Name, 2, true, err)
-		}
-		if mt.Rating < 1 {
-			err = goa.InvalidRangeError(`default view.rating`, mt.Rating, 1, true, err)
-		}
-		if mt.Rating > 5 {
-			err = goa.InvalidRangeError(`default view.rating`, mt.Rating, 5, false, err)
-		}
-		if len(mt.Varietal) < 4 {
-			err = goa.InvalidLengthError(`default view.varietal`, mt.Varietal, 4, true, err)
-		}
-		if len(mt.Vineyard) < 2 {
-			err = goa.InvalidLengthError(`default view.vineyard`, mt.Vineyard, 2, true, err)
-		}
-		if mt.Vintage < 1900 {
-			err = goa.InvalidRangeError(`default view.vintage`, mt.Vintage, 1900, true, err)
-		}
-		if mt.Vintage > 2020 {
-			err = goa.InvalidRangeError(`default view.vintage`, mt.Vintage, 2020, false, err)
-		}
-		tmp50 := map[string]interface{}{
-			"href":     mt.Href,
-			"id":       mt.ID,
-			"name":     mt.Name,
-			"rating":   mt.Rating,
-			"varietal": mt.Varietal,
-			"vineyard": mt.Vineyard,
-			"vintage":  mt.Vintage,
-		}
-		res = tmp50
-		if err == nil {
-			links := make(map[string]interface{})
-			tmp49 := map[string]interface{}{
-				"href": mt.Account.Href,
-				"id":   mt.Account.ID,
-				"name": mt.Account.Name,
-			}
-			links["account"] = tmp49
-			res["links"] = links
-		}
+		res, err = MarshalBottle(mt, err)
 	}
 	if view == BottleFullView {
-		if mt.Color != "" {
-			if !(mt.Color == "red" || mt.Color == "white" || mt.Color == "rose" || mt.Color == "yellow" || mt.Color == "sparkling") {
-				err = goa.InvalidEnumValueError(`full view.color`, mt.Color, []interface{}{"red", "white", "rose", "yellow", "sparkling"}, err)
-			}
-		}
-		if len(mt.Country) < 2 {
-			err = goa.InvalidLengthError(`full view.country`, mt.Country, 2, true, err)
-		}
-		if mt.CreatedAt != "" {
-			if err2 := goa.ValidateFormat(goa.FormatDateTime, mt.CreatedAt); err2 != nil {
-				err = goa.InvalidFormatError(`full view.created_at`, mt.CreatedAt, goa.FormatDateTime, err2, err)
-			}
-		}
-		if len(mt.Name) < 2 {
-			err = goa.InvalidLengthError(`full view.name`, mt.Name, 2, true, err)
-		}
-		if mt.Rating < 1 {
-			err = goa.InvalidRangeError(`full view.rating`, mt.Rating, 1, true, err)
-		}
-		if mt.Rating > 5 {
-			err = goa.InvalidRangeError(`full view.rating`, mt.Rating, 5, false, err)
-		}
-		if len(mt.Review) < 10 {
-			err = goa.InvalidLengthError(`full view.review`, mt.Review, 10, true, err)
-		}
-		if len(mt.Review) > 300 {
-			err = goa.InvalidLengthError(`full view.review`, mt.Review, 300, false, err)
-		}
-		if mt.Sweetness < 1 {
-			err = goa.InvalidRangeError(`full view.sweetness`, mt.Sweetness, 1, true, err)
-		}
-		if mt.Sweetness > 5 {
-			err = goa.InvalidRangeError(`full view.sweetness`, mt.Sweetness, 5, false, err)
-		}
-		if mt.UpdatedAt != "" {
-			if err2 := goa.ValidateFormat(goa.FormatDateTime, mt.UpdatedAt); err2 != nil {
-				err = goa.InvalidFormatError(`full view.updated_at`, mt.UpdatedAt, goa.FormatDateTime, err2, err)
-			}
-		}
-		if len(mt.Varietal) < 4 {
-			err = goa.InvalidLengthError(`full view.varietal`, mt.Varietal, 4, true, err)
-		}
-		if len(mt.Vineyard) < 2 {
-			err = goa.InvalidLengthError(`full view.vineyard`, mt.Vineyard, 2, true, err)
-		}
-		if mt.Vintage < 1900 {
-			err = goa.InvalidRangeError(`full view.vintage`, mt.Vintage, 1900, true, err)
-		}
-		if mt.Vintage > 2020 {
-			err = goa.InvalidRangeError(`full view.vintage`, mt.Vintage, 2020, false, err)
-		}
-		tmp52 := map[string]interface{}{
-			"color":      mt.Color,
-			"country":    mt.Country,
-			"created_at": mt.CreatedAt,
-			"href":       mt.Href,
-			"id":         mt.ID,
-			"name":       mt.Name,
-			"rating":     mt.Rating,
-			"region":     mt.Region,
-			"review":     mt.Review,
-			"sweetness":  mt.Sweetness,
-			"updated_at": mt.UpdatedAt,
-			"varietal":   mt.Varietal,
-			"vineyard":   mt.Vineyard,
-			"vintage":    mt.Vintage,
-		}
-		if mt.Account != nil {
-			if mt.Account.CreatedAt != "" {
-				if err2 := goa.ValidateFormat(goa.FormatDateTime, mt.Account.CreatedAt); err2 != nil {
-					err = goa.InvalidFormatError(`full view.Account.created_at`, mt.Account.CreatedAt, goa.FormatDateTime, err2, err)
-				}
-			}
-			if mt.Account.CreatedBy != "" {
-				if err2 := goa.ValidateFormat(goa.FormatEmail, mt.Account.CreatedBy); err2 != nil {
-					err = goa.InvalidFormatError(`full view.Account.created_by`, mt.Account.CreatedBy, goa.FormatEmail, err2, err)
-				}
-			}
-			tmp53 := map[string]interface{}{
-				"created_at": mt.Account.CreatedAt,
-				"created_by": mt.Account.CreatedBy,
-				"href":       mt.Account.Href,
-				"id":         mt.Account.ID,
-				"name":       mt.Account.Name,
-			}
-			tmp52["account"] = tmp53
-		}
-		res = tmp52
-		if err == nil {
-			links := make(map[string]interface{})
-			tmp51 := map[string]interface{}{
-				"href": mt.Account.Href,
-				"id":   mt.Account.ID,
-				"name": mt.Account.Name,
-			}
-			links["account"] = tmp51
-			res["links"] = links
-		}
+		res, err = MarshalBottleFull(mt, err)
 	}
 	if view == BottleTinyView {
-		if len(mt.Name) < 2 {
-			err = goa.InvalidLengthError(`tiny view.name`, mt.Name, 2, true, err)
-		}
-		if mt.Rating < 1 {
-			err = goa.InvalidRangeError(`tiny view.rating`, mt.Rating, 1, true, err)
-		}
-		if mt.Rating > 5 {
-			err = goa.InvalidRangeError(`tiny view.rating`, mt.Rating, 5, false, err)
-		}
-		tmp55 := map[string]interface{}{
-			"href":   mt.Href,
-			"id":     mt.ID,
-			"name":   mt.Name,
-			"rating": mt.Rating,
-		}
-		res = tmp55
-		if err == nil {
-			links := make(map[string]interface{})
-			tmp54 := map[string]interface{}{
-				"href": mt.Account.Href,
-				"id":   mt.Account.ID,
-				"name": mt.Account.Name,
-			}
-			links["account"] = tmp54
-			res["links"] = links
-		}
+		res, err = MarshalBottleTiny(mt, err)
 	}
-	return res, err
+	return
 }
 
 // Validate validates the media type instance.
@@ -729,6 +311,375 @@ func (mt *Bottle) Validate() (err error) {
 	return
 }
 
+// MarshalBottle validates and renders an instance of Bottle into a interface{}
+// using view "default".
+func MarshalBottle(source *Bottle, inErr error) (target map[string]interface{}, err error) {
+	err = inErr
+	if len(source.Name) < 2 {
+		err = goa.InvalidLengthError(`.name`, source.Name, 2, true, err)
+	}
+	if source.Rating < 1 {
+		err = goa.InvalidRangeError(`.rating`, source.Rating, 1, true, err)
+	}
+	if source.Rating > 5 {
+		err = goa.InvalidRangeError(`.rating`, source.Rating, 5, false, err)
+	}
+	if len(source.Varietal) < 4 {
+		err = goa.InvalidLengthError(`.varietal`, source.Varietal, 4, true, err)
+	}
+	if len(source.Vineyard) < 2 {
+		err = goa.InvalidLengthError(`.vineyard`, source.Vineyard, 2, true, err)
+	}
+	if source.Vintage < 1900 {
+		err = goa.InvalidRangeError(`.vintage`, source.Vintage, 1900, true, err)
+	}
+	if source.Vintage > 2020 {
+		err = goa.InvalidRangeError(`.vintage`, source.Vintage, 2020, false, err)
+	}
+	tmp29 := map[string]interface{}{
+		"href":     source.Href,
+		"id":       source.ID,
+		"name":     source.Name,
+		"rating":   source.Rating,
+		"varietal": source.Varietal,
+		"vineyard": source.Vineyard,
+		"vintage":  source.Vintage,
+	}
+	target = tmp29
+	if err == nil {
+		links := make(map[string]interface{})
+		links["account"], err = MarshalAccountLink(source.Account, err)
+		target["links"] = links
+	}
+	return
+}
+
+// MarshalBottleFull validates and renders an instance of Bottle into a interface{}
+// using view "full".
+func MarshalBottleFull(source *Bottle, inErr error) (target map[string]interface{}, err error) {
+	err = inErr
+	if source.Color != "" {
+		if !(source.Color == "red" || source.Color == "white" || source.Color == "rose" || source.Color == "yellow" || source.Color == "sparkling") {
+			err = goa.InvalidEnumValueError(`.color`, source.Color, []interface{}{"red", "white", "rose", "yellow", "sparkling"}, err)
+		}
+	}
+	if len(source.Country) < 2 {
+		err = goa.InvalidLengthError(`.country`, source.Country, 2, true, err)
+	}
+	if source.CreatedAt != "" {
+		if err2 := goa.ValidateFormat(goa.FormatDateTime, source.CreatedAt); err2 != nil {
+			err = goa.InvalidFormatError(`.created_at`, source.CreatedAt, goa.FormatDateTime, err2, err)
+		}
+	}
+	if len(source.Name) < 2 {
+		err = goa.InvalidLengthError(`.name`, source.Name, 2, true, err)
+	}
+	if source.Rating < 1 {
+		err = goa.InvalidRangeError(`.rating`, source.Rating, 1, true, err)
+	}
+	if source.Rating > 5 {
+		err = goa.InvalidRangeError(`.rating`, source.Rating, 5, false, err)
+	}
+	if len(source.Review) < 10 {
+		err = goa.InvalidLengthError(`.review`, source.Review, 10, true, err)
+	}
+	if len(source.Review) > 300 {
+		err = goa.InvalidLengthError(`.review`, source.Review, 300, false, err)
+	}
+	if source.Sweetness < 1 {
+		err = goa.InvalidRangeError(`.sweetness`, source.Sweetness, 1, true, err)
+	}
+	if source.Sweetness > 5 {
+		err = goa.InvalidRangeError(`.sweetness`, source.Sweetness, 5, false, err)
+	}
+	if source.UpdatedAt != "" {
+		if err2 := goa.ValidateFormat(goa.FormatDateTime, source.UpdatedAt); err2 != nil {
+			err = goa.InvalidFormatError(`.updated_at`, source.UpdatedAt, goa.FormatDateTime, err2, err)
+		}
+	}
+	if len(source.Varietal) < 4 {
+		err = goa.InvalidLengthError(`.varietal`, source.Varietal, 4, true, err)
+	}
+	if len(source.Vineyard) < 2 {
+		err = goa.InvalidLengthError(`.vineyard`, source.Vineyard, 2, true, err)
+	}
+	if source.Vintage < 1900 {
+		err = goa.InvalidRangeError(`.vintage`, source.Vintage, 1900, true, err)
+	}
+	if source.Vintage > 2020 {
+		err = goa.InvalidRangeError(`.vintage`, source.Vintage, 2020, false, err)
+	}
+	tmp30 := map[string]interface{}{
+		"color":      source.Color,
+		"country":    source.Country,
+		"created_at": source.CreatedAt,
+		"href":       source.Href,
+		"id":         source.ID,
+		"name":       source.Name,
+		"rating":     source.Rating,
+		"region":     source.Region,
+		"review":     source.Review,
+		"sweetness":  source.Sweetness,
+		"updated_at": source.UpdatedAt,
+		"varietal":   source.Varietal,
+		"vineyard":   source.Vineyard,
+		"vintage":    source.Vintage,
+	}
+	if source.Account != nil {
+		tmp30["account"], err = MarshalAccount(source.Account, err)
+	}
+	target = tmp30
+	if err == nil {
+		links := make(map[string]interface{})
+		links["account"], err = MarshalAccountLink(source.Account, err)
+		target["links"] = links
+	}
+	return
+}
+
+// MarshalBottleTiny validates and renders an instance of Bottle into a interface{}
+// using view "tiny".
+func MarshalBottleTiny(source *Bottle, inErr error) (target map[string]interface{}, err error) {
+	err = inErr
+	if len(source.Name) < 2 {
+		err = goa.InvalidLengthError(`.name`, source.Name, 2, true, err)
+	}
+	if source.Rating < 1 {
+		err = goa.InvalidRangeError(`.rating`, source.Rating, 1, true, err)
+	}
+	if source.Rating > 5 {
+		err = goa.InvalidRangeError(`.rating`, source.Rating, 5, false, err)
+	}
+	tmp31 := map[string]interface{}{
+		"href":   source.Href,
+		"id":     source.ID,
+		"name":   source.Name,
+		"rating": source.Rating,
+	}
+	target = tmp31
+	if err == nil {
+		links := make(map[string]interface{})
+		links["account"], err = MarshalAccountLink(source.Account, err)
+		target["links"] = links
+	}
+	return
+}
+
+// UnmarshalBottle unmarshals and validates a raw interface{} into an instance of Bottle
+func UnmarshalBottle(source interface{}, inErr error) (target *Bottle, err error) {
+	err = inErr
+	if val, ok := source.(map[string]interface{}); ok {
+		target = new(Bottle)
+		if v, ok := val["account"]; ok {
+			var tmp32 *Account
+			tmp32, err = UnmarshalAccount(v, err)
+			target.Account = tmp32
+		}
+		if v, ok := val["color"]; ok {
+			var tmp33 string
+			if val, ok := v.(string); ok {
+				tmp33 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Color`, v, "string", err)
+			}
+			if err == nil {
+				if tmp33 != "" {
+					if !(tmp33 == "red" || tmp33 == "white" || tmp33 == "rose" || tmp33 == "yellow" || tmp33 == "sparkling") {
+						err = goa.InvalidEnumValueError(`load.Color`, tmp33, []interface{}{"red", "white", "rose", "yellow", "sparkling"}, err)
+					}
+				}
+			}
+			target.Color = tmp33
+		}
+		if v, ok := val["country"]; ok {
+			var tmp34 string
+			if val, ok := v.(string); ok {
+				tmp34 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Country`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp34) < 2 {
+					err = goa.InvalidLengthError(`load.Country`, tmp34, 2, true, err)
+				}
+			}
+			target.Country = tmp34
+		}
+		if v, ok := val["created_at"]; ok {
+			var tmp35 string
+			if val, ok := v.(string); ok {
+				tmp35 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.CreatedAt`, v, "string", err)
+			}
+			if err == nil {
+				if tmp35 != "" {
+					if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp35); err2 != nil {
+						err = goa.InvalidFormatError(`load.CreatedAt`, tmp35, goa.FormatDateTime, err2, err)
+					}
+				}
+			}
+			target.CreatedAt = tmp35
+		}
+		if v, ok := val["href"]; ok {
+			var tmp36 string
+			if val, ok := v.(string); ok {
+				tmp36 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Href`, v, "string", err)
+			}
+			target.Href = tmp36
+		}
+		if v, ok := val["id"]; ok {
+			var tmp37 int
+			if f, ok := v.(float64); ok {
+				tmp37 = int(f)
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.ID`, v, "int", err)
+			}
+			target.ID = tmp37
+		}
+		if v, ok := val["name"]; ok {
+			var tmp38 string
+			if val, ok := v.(string); ok {
+				tmp38 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Name`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp38) < 2 {
+					err = goa.InvalidLengthError(`load.Name`, tmp38, 2, true, err)
+				}
+			}
+			target.Name = tmp38
+		}
+		if v, ok := val["rating"]; ok {
+			var tmp39 int
+			if f, ok := v.(float64); ok {
+				tmp39 = int(f)
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Rating`, v, "int", err)
+			}
+			if err == nil {
+				if tmp39 < 1 {
+					err = goa.InvalidRangeError(`load.Rating`, tmp39, 1, true, err)
+				}
+				if tmp39 > 5 {
+					err = goa.InvalidRangeError(`load.Rating`, tmp39, 5, false, err)
+				}
+			}
+			target.Rating = tmp39
+		}
+		if v, ok := val["region"]; ok {
+			var tmp40 string
+			if val, ok := v.(string); ok {
+				tmp40 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Region`, v, "string", err)
+			}
+			target.Region = tmp40
+		}
+		if v, ok := val["review"]; ok {
+			var tmp41 string
+			if val, ok := v.(string); ok {
+				tmp41 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Review`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp41) < 10 {
+					err = goa.InvalidLengthError(`load.Review`, tmp41, 10, true, err)
+				}
+				if len(tmp41) > 300 {
+					err = goa.InvalidLengthError(`load.Review`, tmp41, 300, false, err)
+				}
+			}
+			target.Review = tmp41
+		}
+		if v, ok := val["sweetness"]; ok {
+			var tmp42 int
+			if f, ok := v.(float64); ok {
+				tmp42 = int(f)
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Sweetness`, v, "int", err)
+			}
+			if err == nil {
+				if tmp42 < 1 {
+					err = goa.InvalidRangeError(`load.Sweetness`, tmp42, 1, true, err)
+				}
+				if tmp42 > 5 {
+					err = goa.InvalidRangeError(`load.Sweetness`, tmp42, 5, false, err)
+				}
+			}
+			target.Sweetness = tmp42
+		}
+		if v, ok := val["updated_at"]; ok {
+			var tmp43 string
+			if val, ok := v.(string); ok {
+				tmp43 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.UpdatedAt`, v, "string", err)
+			}
+			if err == nil {
+				if tmp43 != "" {
+					if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp43); err2 != nil {
+						err = goa.InvalidFormatError(`load.UpdatedAt`, tmp43, goa.FormatDateTime, err2, err)
+					}
+				}
+			}
+			target.UpdatedAt = tmp43
+		}
+		if v, ok := val["varietal"]; ok {
+			var tmp44 string
+			if val, ok := v.(string); ok {
+				tmp44 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Varietal`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp44) < 4 {
+					err = goa.InvalidLengthError(`load.Varietal`, tmp44, 4, true, err)
+				}
+			}
+			target.Varietal = tmp44
+		}
+		if v, ok := val["vineyard"]; ok {
+			var tmp45 string
+			if val, ok := v.(string); ok {
+				tmp45 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Vineyard`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp45) < 2 {
+					err = goa.InvalidLengthError(`load.Vineyard`, tmp45, 2, true, err)
+				}
+			}
+			target.Vineyard = tmp45
+		}
+		if v, ok := val["vintage"]; ok {
+			var tmp46 int
+			if f, ok := v.(float64); ok {
+				tmp46 = int(f)
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Vintage`, v, "int", err)
+			}
+			if err == nil {
+				if tmp46 < 1900 {
+					err = goa.InvalidRangeError(`load.Vintage`, tmp46, 1900, true, err)
+				}
+				if tmp46 > 2020 {
+					err = goa.InvalidRangeError(`load.Vintage`, tmp46, 2020, false, err)
+				}
+			}
+			target.Vintage = tmp46
+		}
+	} else {
+		err = goa.InvalidAttributeTypeError(`load`, source, "dictionary", err)
+	}
+	return
+}
+
 // BottleCollection media type
 // Identifier: application/vnd.goa.example.bottle+json; type=collection
 type BottleCollection []*Bottle
@@ -747,376 +698,31 @@ const (
 // validations. Raw data is defined by data that the JSON unmarshaler would create when unmarshaling
 // into a variable of type interface{}. See https://golang.org/pkg/encoding/json/#Unmarshal for the
 // complete list of supported data types.
-func LoadBottleCollection(raw interface{}) (BottleCollection, error) {
-	var err error
-	var res BottleCollection
-	if val, ok := raw.([]interface{}); ok {
-		res = make([]*Bottle, len(val))
-		for i, v := range val {
-			var tmp56 *Bottle
-			if val, ok := v.(map[string]interface{}); ok {
-				tmp56 = new(Bottle)
-				if v, ok := val["account"]; ok {
-					var tmp57 *Account
-					if val, ok := v.(map[string]interface{}); ok {
-						tmp57 = new(Account)
-						if v, ok := val["created_at"]; ok {
-							var tmp58 string
-							if val, ok := v.(string); ok {
-								tmp58 = val
-							} else {
-								err = goa.InvalidAttributeTypeError(`[*].Account.CreatedAt`, v, "string", err)
-							}
-							if err == nil {
-								if tmp58 != "" {
-									if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp58); err2 != nil {
-										err = goa.InvalidFormatError(`[*].Account.CreatedAt`, tmp58, goa.FormatDateTime, err2, err)
-									}
-								}
-							}
-							tmp57.CreatedAt = tmp58
-						}
-						if v, ok := val["created_by"]; ok {
-							var tmp59 string
-							if val, ok := v.(string); ok {
-								tmp59 = val
-							} else {
-								err = goa.InvalidAttributeTypeError(`[*].Account.CreatedBy`, v, "string", err)
-							}
-							if err == nil {
-								if tmp59 != "" {
-									if err2 := goa.ValidateFormat(goa.FormatEmail, tmp59); err2 != nil {
-										err = goa.InvalidFormatError(`[*].Account.CreatedBy`, tmp59, goa.FormatEmail, err2, err)
-									}
-								}
-							}
-							tmp57.CreatedBy = tmp59
-						}
-						if v, ok := val["href"]; ok {
-							var tmp60 string
-							if val, ok := v.(string); ok {
-								tmp60 = val
-							} else {
-								err = goa.InvalidAttributeTypeError(`[*].Account.Href`, v, "string", err)
-							}
-							tmp57.Href = tmp60
-						}
-						if v, ok := val["id"]; ok {
-							var tmp61 int
-							if f, ok := v.(float64); ok {
-								tmp61 = int(f)
-							} else {
-								err = goa.InvalidAttributeTypeError(`[*].Account.ID`, v, "int", err)
-							}
-							tmp57.ID = tmp61
-						}
-						if v, ok := val["name"]; ok {
-							var tmp62 string
-							if val, ok := v.(string); ok {
-								tmp62 = val
-							} else {
-								err = goa.InvalidAttributeTypeError(`[*].Account.Name`, v, "string", err)
-							}
-							tmp57.Name = tmp62
-						}
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Account`, v, "dictionary", err)
-					}
-					tmp56.Account = tmp57
-				}
-				if v, ok := val["color"]; ok {
-					var tmp63 string
-					if val, ok := v.(string); ok {
-						tmp63 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Color`, v, "string", err)
-					}
-					if err == nil {
-						if tmp63 != "" {
-							if !(tmp63 == "red" || tmp63 == "white" || tmp63 == "rose" || tmp63 == "yellow" || tmp63 == "sparkling") {
-								err = goa.InvalidEnumValueError(`[*].Color`, tmp63, []interface{}{"red", "white", "rose", "yellow", "sparkling"}, err)
-							}
-						}
-					}
-					tmp56.Color = tmp63
-				}
-				if v, ok := val["country"]; ok {
-					var tmp64 string
-					if val, ok := v.(string); ok {
-						tmp64 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Country`, v, "string", err)
-					}
-					if err == nil {
-						if len(tmp64) < 2 {
-							err = goa.InvalidLengthError(`[*].Country`, tmp64, 2, true, err)
-						}
-					}
-					tmp56.Country = tmp64
-				}
-				if v, ok := val["created_at"]; ok {
-					var tmp65 string
-					if val, ok := v.(string); ok {
-						tmp65 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].CreatedAt`, v, "string", err)
-					}
-					if err == nil {
-						if tmp65 != "" {
-							if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp65); err2 != nil {
-								err = goa.InvalidFormatError(`[*].CreatedAt`, tmp65, goa.FormatDateTime, err2, err)
-							}
-						}
-					}
-					tmp56.CreatedAt = tmp65
-				}
-				if v, ok := val["href"]; ok {
-					var tmp66 string
-					if val, ok := v.(string); ok {
-						tmp66 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Href`, v, "string", err)
-					}
-					tmp56.Href = tmp66
-				}
-				if v, ok := val["id"]; ok {
-					var tmp67 int
-					if f, ok := v.(float64); ok {
-						tmp67 = int(f)
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].ID`, v, "int", err)
-					}
-					tmp56.ID = tmp67
-				}
-				if v, ok := val["name"]; ok {
-					var tmp68 string
-					if val, ok := v.(string); ok {
-						tmp68 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Name`, v, "string", err)
-					}
-					if err == nil {
-						if len(tmp68) < 2 {
-							err = goa.InvalidLengthError(`[*].Name`, tmp68, 2, true, err)
-						}
-					}
-					tmp56.Name = tmp68
-				}
-				if v, ok := val["rating"]; ok {
-					var tmp69 int
-					if f, ok := v.(float64); ok {
-						tmp69 = int(f)
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Rating`, v, "int", err)
-					}
-					if err == nil {
-						if tmp69 < 1 {
-							err = goa.InvalidRangeError(`[*].Rating`, tmp69, 1, true, err)
-						}
-						if tmp69 > 5 {
-							err = goa.InvalidRangeError(`[*].Rating`, tmp69, 5, false, err)
-						}
-					}
-					tmp56.Rating = tmp69
-				}
-				if v, ok := val["region"]; ok {
-					var tmp70 string
-					if val, ok := v.(string); ok {
-						tmp70 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Region`, v, "string", err)
-					}
-					tmp56.Region = tmp70
-				}
-				if v, ok := val["review"]; ok {
-					var tmp71 string
-					if val, ok := v.(string); ok {
-						tmp71 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Review`, v, "string", err)
-					}
-					if err == nil {
-						if len(tmp71) < 10 {
-							err = goa.InvalidLengthError(`[*].Review`, tmp71, 10, true, err)
-						}
-						if len(tmp71) > 300 {
-							err = goa.InvalidLengthError(`[*].Review`, tmp71, 300, false, err)
-						}
-					}
-					tmp56.Review = tmp71
-				}
-				if v, ok := val["sweetness"]; ok {
-					var tmp72 int
-					if f, ok := v.(float64); ok {
-						tmp72 = int(f)
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Sweetness`, v, "int", err)
-					}
-					if err == nil {
-						if tmp72 < 1 {
-							err = goa.InvalidRangeError(`[*].Sweetness`, tmp72, 1, true, err)
-						}
-						if tmp72 > 5 {
-							err = goa.InvalidRangeError(`[*].Sweetness`, tmp72, 5, false, err)
-						}
-					}
-					tmp56.Sweetness = tmp72
-				}
-				if v, ok := val["updated_at"]; ok {
-					var tmp73 string
-					if val, ok := v.(string); ok {
-						tmp73 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].UpdatedAt`, v, "string", err)
-					}
-					if err == nil {
-						if tmp73 != "" {
-							if err2 := goa.ValidateFormat(goa.FormatDateTime, tmp73); err2 != nil {
-								err = goa.InvalidFormatError(`[*].UpdatedAt`, tmp73, goa.FormatDateTime, err2, err)
-							}
-						}
-					}
-					tmp56.UpdatedAt = tmp73
-				}
-				if v, ok := val["varietal"]; ok {
-					var tmp74 string
-					if val, ok := v.(string); ok {
-						tmp74 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Varietal`, v, "string", err)
-					}
-					if err == nil {
-						if len(tmp74) < 4 {
-							err = goa.InvalidLengthError(`[*].Varietal`, tmp74, 4, true, err)
-						}
-					}
-					tmp56.Varietal = tmp74
-				}
-				if v, ok := val["vineyard"]; ok {
-					var tmp75 string
-					if val, ok := v.(string); ok {
-						tmp75 = val
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Vineyard`, v, "string", err)
-					}
-					if err == nil {
-						if len(tmp75) < 2 {
-							err = goa.InvalidLengthError(`[*].Vineyard`, tmp75, 2, true, err)
-						}
-					}
-					tmp56.Vineyard = tmp75
-				}
-				if v, ok := val["vintage"]; ok {
-					var tmp76 int
-					if f, ok := v.(float64); ok {
-						tmp76 = int(f)
-					} else {
-						err = goa.InvalidAttributeTypeError(`[*].Vintage`, v, "int", err)
-					}
-					if err == nil {
-						if tmp76 < 1900 {
-							err = goa.InvalidRangeError(`[*].Vintage`, tmp76, 1900, true, err)
-						}
-						if tmp76 > 2020 {
-							err = goa.InvalidRangeError(`[*].Vintage`, tmp76, 2020, false, err)
-						}
-					}
-					tmp56.Vintage = tmp76
-				}
-			} else {
-				err = goa.InvalidAttributeTypeError(`[*]`, v, "dictionary", err)
-			}
-			res[i] = tmp56
-		}
-	} else {
-		err = goa.InvalidAttributeTypeError(``, raw, "array", err)
-	}
-	return res, err
+func LoadBottleCollection(raw interface{}) (res BottleCollection, err error) {
+	res, err = UnmarshalBottleCollection(raw, err)
+	return
 }
 
 // Dump produces raw data from an instance of BottleCollection running all the
 // validations. See LoadBottleCollection for the definition of raw data.
-func (mt BottleCollection) Dump(view BottleCollectionViewEnum) ([]map[string]interface{}, error) {
-	var err error
-	var res []map[string]interface{}
+func (mt BottleCollection) Dump(view BottleCollectionViewEnum) (res []map[string]interface{}, err error) {
 	if view == BottleCollectionDefaultView {
 		res = make([]map[string]interface{}, len(mt))
-		for i, tmp77 := range mt {
-			if len(tmp77.Name) < 2 {
-				err = goa.InvalidLengthError(`default view[*].name`, tmp77.Name, 2, true, err)
-			}
-			if tmp77.Rating < 1 {
-				err = goa.InvalidRangeError(`default view[*].rating`, tmp77.Rating, 1, true, err)
-			}
-			if tmp77.Rating > 5 {
-				err = goa.InvalidRangeError(`default view[*].rating`, tmp77.Rating, 5, false, err)
-			}
-			if len(tmp77.Varietal) < 4 {
-				err = goa.InvalidLengthError(`default view[*].varietal`, tmp77.Varietal, 4, true, err)
-			}
-			if len(tmp77.Vineyard) < 2 {
-				err = goa.InvalidLengthError(`default view[*].vineyard`, tmp77.Vineyard, 2, true, err)
-			}
-			if tmp77.Vintage < 1900 {
-				err = goa.InvalidRangeError(`default view[*].vintage`, tmp77.Vintage, 1900, true, err)
-			}
-			if tmp77.Vintage > 2020 {
-				err = goa.InvalidRangeError(`default view[*].vintage`, tmp77.Vintage, 2020, false, err)
-			}
-			tmp79 := map[string]interface{}{
-				"href":     tmp77.Href,
-				"id":       tmp77.ID,
-				"name":     tmp77.Name,
-				"rating":   tmp77.Rating,
-				"varietal": tmp77.Varietal,
-				"vineyard": tmp77.Vineyard,
-				"vintage":  tmp77.Vintage,
-			}
-			res[i] = tmp79
-			if err == nil {
-				links := make(map[string]interface{})
-				tmp78 := map[string]interface{}{
-					"href": tmp77.Account.Href,
-					"id":   tmp77.Account.ID,
-					"name": tmp77.Account.Name,
-				}
-				links["account"] = tmp78
-				res[i]["links"] = links
-			}
+		for i, tmp47 := range mt {
+			var tmp48 map[string]interface{}
+			tmp48, err = MarshalBottle(tmp47, err)
+			res[i] = tmp48
 		}
 	}
 	if view == BottleCollectionTinyView {
 		res = make([]map[string]interface{}, len(mt))
-		for i, tmp80 := range mt {
-			if len(tmp80.Name) < 2 {
-				err = goa.InvalidLengthError(`tiny view[*].name`, tmp80.Name, 2, true, err)
-			}
-			if tmp80.Rating < 1 {
-				err = goa.InvalidRangeError(`tiny view[*].rating`, tmp80.Rating, 1, true, err)
-			}
-			if tmp80.Rating > 5 {
-				err = goa.InvalidRangeError(`tiny view[*].rating`, tmp80.Rating, 5, false, err)
-			}
-			tmp82 := map[string]interface{}{
-				"href":   tmp80.Href,
-				"id":     tmp80.ID,
-				"name":   tmp80.Name,
-				"rating": tmp80.Rating,
-			}
-			res[i] = tmp82
-			if err == nil {
-				links := make(map[string]interface{})
-				tmp81 := map[string]interface{}{
-					"href": tmp80.Account.Href,
-					"id":   tmp80.Account.ID,
-					"name": tmp80.Account.Name,
-				}
-				links["account"] = tmp81
-				res[i]["links"] = links
-			}
+		for i, tmp49 := range mt {
+			var tmp50 map[string]interface{}
+			tmp50, err = MarshalBottleTiny(tmp49, err)
+			res[i] = tmp50
 		}
 	}
-	return res, err
+	return
 }
 
 // Validate validates the media type instance.
@@ -1183,6 +789,42 @@ func (mt BottleCollection) Validate() (err error) {
 		if e.Vintage > 2020 {
 			err = goa.InvalidRangeError(`response[*].vintage`, e.Vintage, 2020, false, err)
 		}
+	}
+	return
+}
+
+// MarshalBottleCollection validates and renders an instance of BottleCollection into a interface{}
+// using view "default".
+func MarshalBottleCollection(source BottleCollection, inErr error) (target []map[string]interface{}, err error) {
+	err = inErr
+	target = make([]map[string]interface{}, len(source))
+	for i, res := range source {
+		target[i], err = MarshalBottle(res, err)
+	}
+	return
+}
+
+// MarshalBottleCollectionTiny validates and renders an instance of BottleCollection into a interface{}
+// using view "tiny".
+func MarshalBottleCollectionTiny(source BottleCollection, inErr error) (target []map[string]interface{}, err error) {
+	err = inErr
+	target = make([]map[string]interface{}, len(source))
+	for i, res := range source {
+		target[i], err = MarshalBottleTiny(res, err)
+	}
+	return
+}
+
+// UnmarshalBottleCollection unmarshals and validates a raw interface{} into an instance of BottleCollection
+func UnmarshalBottleCollection(source interface{}, inErr error) (target BottleCollection, err error) {
+	err = inErr
+	if val, ok := source.([]interface{}); ok {
+		target = make([]*Bottle, len(val))
+		for i, v := range val {
+			target[i], err = UnmarshalBottle(v, err)
+		}
+	} else {
+		err = goa.InvalidAttributeTypeError(`load`, source, "array", err)
 	}
 	return
 }

--- a/examples/cellar/app/user_types.go
+++ b/examples/cellar/app/user_types.go
@@ -12,6 +12,8 @@
 
 package app
 
+import "github.com/raphael/goa"
+
 // BottlePayload type
 type BottlePayload struct {
 	Color     string
@@ -23,4 +25,200 @@ type BottlePayload struct {
 	Varietal  string
 	Vineyard  string
 	Vintage   int
+}
+
+// MarshalBottlePayload validates and renders an instance of BottlePayload into a interface{}
+func MarshalBottlePayload(source *BottlePayload, inErr error) (target map[string]interface{}, err error) {
+	err = inErr
+	if source.Color != "" {
+		if !(source.Color == "red" || source.Color == "white" || source.Color == "rose" || source.Color == "yellow" || source.Color == "sparkling") {
+			err = goa.InvalidEnumValueError(`.color`, source.Color, []interface{}{"red", "white", "rose", "yellow", "sparkling"}, err)
+		}
+	}
+	if len(source.Country) < 2 {
+		err = goa.InvalidLengthError(`.country`, source.Country, 2, true, err)
+	}
+	if len(source.Name) < 2 {
+		err = goa.InvalidLengthError(`.name`, source.Name, 2, true, err)
+	}
+	if len(source.Review) < 10 {
+		err = goa.InvalidLengthError(`.review`, source.Review, 10, true, err)
+	}
+	if len(source.Review) > 300 {
+		err = goa.InvalidLengthError(`.review`, source.Review, 300, false, err)
+	}
+	if source.Sweetness < 1 {
+		err = goa.InvalidRangeError(`.sweetness`, source.Sweetness, 1, true, err)
+	}
+	if source.Sweetness > 5 {
+		err = goa.InvalidRangeError(`.sweetness`, source.Sweetness, 5, false, err)
+	}
+	if len(source.Varietal) < 4 {
+		err = goa.InvalidLengthError(`.varietal`, source.Varietal, 4, true, err)
+	}
+	if len(source.Vineyard) < 2 {
+		err = goa.InvalidLengthError(`.vineyard`, source.Vineyard, 2, true, err)
+	}
+	if source.Vintage < 1900 {
+		err = goa.InvalidRangeError(`.vintage`, source.Vintage, 1900, true, err)
+	}
+	if source.Vintage > 2020 {
+		err = goa.InvalidRangeError(`.vintage`, source.Vintage, 2020, false, err)
+	}
+	tmp51 := map[string]interface{}{
+		"color":     source.Color,
+		"country":   source.Country,
+		"name":      source.Name,
+		"region":    source.Region,
+		"review":    source.Review,
+		"sweetness": source.Sweetness,
+		"varietal":  source.Varietal,
+		"vineyard":  source.Vineyard,
+		"vintage":   source.Vintage,
+	}
+	target = tmp51
+	return
+}
+
+// UnmarshalBottlePayload unmarshals and validates a raw interface{} into an instance of BottlePayload
+func UnmarshalBottlePayload(source interface{}, inErr error) (target *BottlePayload, err error) {
+	err = inErr
+	if val, ok := source.(map[string]interface{}); ok {
+		target = new(BottlePayload)
+		if v, ok := val["color"]; ok {
+			var tmp52 string
+			if val, ok := v.(string); ok {
+				tmp52 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Color`, v, "string", err)
+			}
+			if err == nil {
+				if tmp52 != "" {
+					if !(tmp52 == "red" || tmp52 == "white" || tmp52 == "rose" || tmp52 == "yellow" || tmp52 == "sparkling") {
+						err = goa.InvalidEnumValueError(`load.Color`, tmp52, []interface{}{"red", "white", "rose", "yellow", "sparkling"}, err)
+					}
+				}
+			}
+			target.Color = tmp52
+		}
+		if v, ok := val["country"]; ok {
+			var tmp53 string
+			if val, ok := v.(string); ok {
+				tmp53 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Country`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp53) < 2 {
+					err = goa.InvalidLengthError(`load.Country`, tmp53, 2, true, err)
+				}
+			}
+			target.Country = tmp53
+		}
+		if v, ok := val["name"]; ok {
+			var tmp54 string
+			if val, ok := v.(string); ok {
+				tmp54 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Name`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp54) < 2 {
+					err = goa.InvalidLengthError(`load.Name`, tmp54, 2, true, err)
+				}
+			}
+			target.Name = tmp54
+		}
+		if v, ok := val["region"]; ok {
+			var tmp55 string
+			if val, ok := v.(string); ok {
+				tmp55 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Region`, v, "string", err)
+			}
+			target.Region = tmp55
+		}
+		if v, ok := val["review"]; ok {
+			var tmp56 string
+			if val, ok := v.(string); ok {
+				tmp56 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Review`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp56) < 10 {
+					err = goa.InvalidLengthError(`load.Review`, tmp56, 10, true, err)
+				}
+				if len(tmp56) > 300 {
+					err = goa.InvalidLengthError(`load.Review`, tmp56, 300, false, err)
+				}
+			}
+			target.Review = tmp56
+		}
+		if v, ok := val["sweetness"]; ok {
+			var tmp57 int
+			if f, ok := v.(float64); ok {
+				tmp57 = int(f)
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Sweetness`, v, "int", err)
+			}
+			if err == nil {
+				if tmp57 < 1 {
+					err = goa.InvalidRangeError(`load.Sweetness`, tmp57, 1, true, err)
+				}
+				if tmp57 > 5 {
+					err = goa.InvalidRangeError(`load.Sweetness`, tmp57, 5, false, err)
+				}
+			}
+			target.Sweetness = tmp57
+		}
+		if v, ok := val["varietal"]; ok {
+			var tmp58 string
+			if val, ok := v.(string); ok {
+				tmp58 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Varietal`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp58) < 4 {
+					err = goa.InvalidLengthError(`load.Varietal`, tmp58, 4, true, err)
+				}
+			}
+			target.Varietal = tmp58
+		}
+		if v, ok := val["vineyard"]; ok {
+			var tmp59 string
+			if val, ok := v.(string); ok {
+				tmp59 = val
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Vineyard`, v, "string", err)
+			}
+			if err == nil {
+				if len(tmp59) < 2 {
+					err = goa.InvalidLengthError(`load.Vineyard`, tmp59, 2, true, err)
+				}
+			}
+			target.Vineyard = tmp59
+		}
+		if v, ok := val["vintage"]; ok {
+			var tmp60 int
+			if f, ok := v.(float64); ok {
+				tmp60 = int(f)
+			} else {
+				err = goa.InvalidAttributeTypeError(`load.Vintage`, v, "int", err)
+			}
+			if err == nil {
+				if tmp60 < 1900 {
+					err = goa.InvalidRangeError(`load.Vintage`, tmp60, 1900, true, err)
+				}
+				if tmp60 > 2020 {
+					err = goa.InvalidRangeError(`load.Vintage`, tmp60, 2020, false, err)
+				}
+			}
+			target.Vintage = tmp60
+		}
+	} else {
+		err = goa.InvalidAttributeTypeError(`load`, source, "dictionary", err)
+	}
+	return
 }

--- a/examples/cellar/design/media_types.go
+++ b/examples/cellar/design/media_types.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Account is the account resource media type.
-var Account = MediaType("application/vnd.goa.example.account+json", func() {
+var Account = MediaType("application/vnd.account+json", func() {
 	Description("A tenant account")
 	Attributes(func() {
 		Attribute("id", Integer, "ID of account")
@@ -36,7 +36,7 @@ var Account = MediaType("application/vnd.goa.example.account+json", func() {
 })
 
 // Bottle is the bottle resource media type.
-var Bottle = MediaType("application/vnd.goa.example.bottle+json", func() {
+var Bottle = MediaType("application/vnd.bottle+json", func() {
 	Description("A bottle of wine")
 	Reference(BottlePayload)
 	Attributes(func() {

--- a/goagen/codegen/types_test.go
+++ b/goagen/codegen/types_test.go
@@ -492,7 +492,7 @@ var _ = Describe("code generation", func() {
 
 			It("generates the marshaler code", func() {
 				Ω(marshaler).Should(Equal(mtMarshaled))
-				Ω(marshaler2).Should(Equal(mtMarshaled))
+				Ω(marshaler2).Should(Equal(mtMarshaled2))
 			})
 		})
 
@@ -620,7 +620,8 @@ const (
 		err = goa.InvalidAttributeTypeError(` + "``" + `, raw, "dictionary", err)
 	}`
 
-	mtMarshaled = `	p, err = MarshalApplication(raw, err)`
+	mtMarshaled  = `	p, err = MarshalTest(raw, err)`
+	mtMarshaled2 = `	p, err = MarshalTest2(raw, err)`
 
 	mtMarshaledImpl = `	tmp1 := map[string]interface{}{
 	}

--- a/goagen/codegen/types_test.go
+++ b/goagen/codegen/types_test.go
@@ -456,6 +456,46 @@ var _ = Describe("code generation", func() {
 				Ω(marshaler).Should(Equal(mtMarshaled))
 			})
 		})
+
+		Context("with two media types referring to each other", func() {
+			var testMediaType *MediaTypeDefinition
+			var testMediaType2 *MediaTypeDefinition
+			var marshaler2 string
+
+			BeforeEach(func() {
+				Design = nil
+				Errors = nil
+				testMediaType = MediaType("application/test", func() {
+					Attribute("id")
+					Attribute("test2", CollectionOf("application/test2"))
+					View("default", func() {
+						Attribute("id")
+					})
+				})
+				Ω(Errors).ShouldNot(HaveOccurred())
+				testMediaType2 = MediaType("application/test2", func() {
+					Attribute("id")
+					Attribute("test", testMediaType)
+					View("default", func() {
+						Attribute("test")
+					})
+				})
+				Ω(Errors).ShouldNot(HaveOccurred())
+				RunDSL()
+				Ω(Errors).ShouldNot(HaveOccurred())
+			})
+
+			JustBeforeEach(func() {
+				marshaler = codegen.MediaTypeMarshaler(testMediaType, context, source, target, "")
+				marshaler2 = codegen.MediaTypeMarshaler(testMediaType2, context, source, target, "")
+			})
+
+			It("generates the marshaler code", func() {
+				Ω(marshaler).Should(Equal(mtMarshaled))
+				Ω(marshaler2).Should(Equal(mtMarshaled))
+			})
+		})
+
 	})
 })
 

--- a/goagen/codegen/validation.go
+++ b/goagen/codegen/validation.go
@@ -198,10 +198,10 @@ const (
 {{tabs .depth}}}{{end}}`
 
 	enumValTmpl = `{{$depth := or (and (and (not .required) (eq .attribute.Type.Kind 4)) (add .depth 1)) .depth}}{{if not .required}}{{if eq .attribute.Type.Kind 4}}{{tabs .depth}}if {{.target}} != "" {
-{{else if gt .attribute.Type.Kind 4}}{{tabs $depth}}if {{.target}} != nil {
+{{else if (not .attribute.Type.IsPrimitive)}}{{tabs $depth}}if {{.target}} != nil {
 {{end}}{{end}}{{tabs $depth}}if !({{oneof .target .values}}) {
 {{tabs $depth}}	err = goa.InvalidEnumValueError(` + "`" + `{{.context}}` + "`" + `, {{.target}}, {{slice .values}}, err)
-{{if and (not .required) (gt .attribute.Type.Kind 3)}}{{tabs $depth}}	}
+{{if and (not .required) (or (eq .attribute.Type.Kind 4) (not .attribute.Type.IsPrimitive))}}{{tabs $depth}}	}
 {{end}}{{tabs .depth}}}`
 
 	patternValTmpl = `{{$depth := or (and (not .required) (add .depth 1)) .depth}}{{if not .required}}{{tabs .depth}}if {{.target}} != "" {
@@ -226,7 +226,7 @@ const (
 
 	requiredValTmpl = `{{$ctx := .}}{{range $r := .required}}{{$catt := index $ctx.attribute.Type.ToObject $r}}{{if eq $catt.Type.Kind 4}}{{tabs $ctx.depth}}if {{$ctx.target}}.{{goify $r true}} == "" {
 {{tabs $ctx.depth}}	err = goa.MissingAttributeError(` + "`" + `{{$ctx.context}}` + "`" + `, "{{$r}}", err)
-{{tabs $ctx.depth}}}{{else if gt $catt.Type.Kind 4}}{{tabs $ctx.depth}}if {{$ctx.target}}.{{goify $r true}} == nil {
+{{tabs $ctx.depth}}}{{else if (not $catt.Type.IsPrimitive)}}{{tabs $ctx.depth}}if {{$ctx.target}}.{{goify $r true}} == nil {
 {{tabs $ctx.depth}}	err = goa.MissingAttributeError(` + "`" + `{{$ctx.context}}` + "`" + `, "{{$r}}", err)
 {{tabs $ctx.depth}}}{{end}}
 {{end}}`


### PR DESCRIPTION
Fixes #97. This PR makes if possible for type definitions to refer to each other.
It also fixes a few issues with code generation around user types.
Finally it gets away with a few unnecessary use of temporary variables.

The basic idea for handling cyclic definitions is to introduce intermediary methods
that handle the type marshaling and unmarshaling and to call these methods instead
of generating the code statically (in which case the code generation would loop
indefinitely).