### PR TITLE
Fix bug with resource BaseParams DSL.

### DIFF
--- a/design/dsl/api_test.go
+++ b/design/dsl/api_test.go
@@ -191,6 +191,31 @@ var _ = Describe("API", func() {
 				Ω(params[param1Name].Description).Should(Equal(param1Desc))
 				Ω(params[param2Name].Description).Should(Equal(param2Desc))
 			})
+
+			Context("and a BasePath using them", func() {
+				const basePath = "/:accountID/:id"
+
+				BeforeEach(func() {
+					prevDSL := dsl
+					dsl = func() {
+						BasePath(basePath)
+						prevDSL()
+					}
+				})
+
+				It("sets both the base path and parameters", func() {
+					Ω(Design.BaseParams.Type).Should(BeAssignableToTypeOf(Object{}))
+					params := Design.BaseParams.Type.ToObject()
+					Ω(params).Should(HaveLen(2))
+					Ω(params).Should(HaveKey(param1Name))
+					Ω(params).Should(HaveKey(param2Name))
+					Ω(params[param1Name].Type).Should(Equal(param1Type))
+					Ω(params[param2Name].Type).Should(Equal(param2Type))
+					Ω(params[param1Name].Description).Should(Equal(param1Desc))
+					Ω(params[param2Name].Description).Should(Equal(param2Desc))
+					Ω(Design.BasePath).Should(Equal(basePath))
+				})
+			})
 		})
 
 		Context("with ResponseTemplates", func() {

--- a/design/dsl/resource_test.go
+++ b/design/dsl/resource_test.go
@@ -166,6 +166,8 @@ var _ = Describe("Resource", func() {
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.BasePath).Should(Equal(basePath))
 			Ω(res.BaseParams).ShouldNot(BeNil())
+			Ω(res.BaseParams.Type).ShouldNot(BeNil())
+			Ω(res.BaseParams.Type.ToObject()).Should(HaveKey("paramID"))
 		})
 	})
 

--- a/design/dsl/resource_test.go
+++ b/design/dsl/resource_test.go
@@ -148,6 +148,27 @@ var _ = Describe("Resource", func() {
 		})
 	})
 
+	Context("with base params", func() {
+		const basePath = "basePath/:paramID"
+
+		BeforeEach(func() {
+			name = "foo"
+			dsl = func() {
+				BasePath(basePath)
+				BaseParams(func() {
+					Param("paramID")
+				})
+			}
+		})
+
+		It("sets the base path and params", func() {
+			Ω(res).ShouldNot(BeNil())
+			Ω(res.Validate()).ShouldNot(HaveOccurred())
+			Ω(res.BasePath).Should(Equal(basePath))
+			Ω(res.BaseParams).ShouldNot(BeNil())
+		})
+	})
+
 	Context("with a media type name", func() {
 		const mediaType = "application/mt"
 

--- a/design/validation.go
+++ b/design/validation.go
@@ -208,7 +208,7 @@ func (r *ResourceDefinition) Validate() *ValidationErrors {
 			verr.Add(r, "invalid type for BaseParams, must be an Object", r)
 		} else {
 			vars := ExtractWildcards(r.BasePath)
-			if len(vars) > 1 {
+			if len(vars) > 0 {
 				if len(vars) != len(baseParams) {
 					verr.Add(r, "BasePath defines parameters %s but BaseParams has %d elements",
 						strings.Join([]string{
@@ -233,7 +233,7 @@ func (r *ResourceDefinition) Validate() *ValidationErrors {
 				}
 			} else {
 				if len(baseParams) > 0 {
-					verr.Add(r, "BasePath does not use variables defines in BaseParams")
+					verr.Add(r, "BasePath does not use variables defined in BaseParams")
 				}
 			}
 		}


### PR DESCRIPTION
The implementation would fail if the base path defined only one parameter.