### PR TITLE
Build goagen before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DEPEND=golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports \
 
 .PHONY: goagen
 
-all: depend lint test goagen
+all: depend lint goagen test
 
 depend:
 	@go get $(DEPEND)


### PR DESCRIPTION
So that tests that depend on it use the latest.