### PR TITLE
update query values after setting them

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -589,7 +589,8 @@ func (c *Client) {{$funcName}}(path string{{if .Payload}}, payload {{if .Payload
 {{range $name, $att := $params.Type.ToObject}}{{if (eq $att.Type.Kind 4)}}	values.Set("{{$name}}", {{goify $name false}})
 {{else}}{{$tmp := tempvar}}{{toString (goify $name false) $tmp $att}}
 	values.Set("{{$name}}", {{$tmp}})
-{{end}}{{end}}{{end}}{{end}}req, err := http.NewRequest({{$route := index .Routes 0}}"{{$route.Verb}}", u.String(), body)
+{{end}}{{end}}{{end}}{{end}}u.RawQuery = values.Encode()
+	req, err := http.NewRequest({{$route := index .Routes 0}}"{{$route.Verb}}", u.String(), body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Current behavior of generated code is to set query string values but never write them back to the URL. This should fix that (but do note that if I've changed the wrong file here, yell at me. I haven't tested it very well, just by sed on my current code.)