### PR TITLE
BREAKING: decode request.Body only with the right Content-Type header

### DIFF
--- a/design/dsl/action.go
+++ b/design/dsl/action.go
@@ -206,7 +206,7 @@ func Params(dsl func()) {
 //
 //	 Payload(BottlePayload)	   // Request payload is described by the BottlePayload type
 //
-//	 Payload(func() {          // Request payload is described inline
+//	 Payload(func() {          // Request payload is an object and is described inline
 //	 	Member("Name")
 //	 })
 //

--- a/service.go
+++ b/service.go
@@ -327,12 +327,17 @@ func (ctrl *ApplicationController) NewHTTPRouterHandle(actName string, h Handler
 			query[name] = value
 		}
 
-		// Load body if any
+		// Build up payload, decoding JSON as necessary
 		var payload interface{}
 		var err error
 		if r.ContentLength > 0 {
-			decoder := json.NewDecoder(r.Body)
-			err = decoder.Decode(&payload)
+			contentType := r.Header.Get("Content-Type")
+			if contentType == "application/json" || contentType == "" {
+				decoder := json.NewDecoder(r.Body)
+				err = decoder.Decode(&payload)
+			}
+
+			// TODO: support othe content types here
 		}
 
 		// Build context


### PR DESCRIPTION
BREAKING CHANGE: to open the door for supporting multiple Content-Type in
incoming requests, we now only decode the req.Body as JSON when the client
specifies "application/json" in the "Content-Type" header, or when that
header is empty.

Eventually, we will implement other decoders to build up the payload.

This change allows someone to receive an incoming "application/octet-stream"
by simply reading the "ctx.Request().Body" .. or handle other types
in the controller.

[Also includes a minor doc addition.]