### PR TITLE
Make cancelation configurable for Graceful application

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -29,6 +29,9 @@ type GracefulApplication struct {
 
 	// Interrupted is true if the application is in the process of shutting down.
 	Interrupted bool
+
+	// CancelOnShutdown tells whether existing requests should be canceled when shutdown is triggered.
+	CancelOnShutdown bool
 }
 
 // InterruptSignals is the list of signals that initiate graceful shutdown.
@@ -41,9 +44,9 @@ var InterruptSignals = []os.Signal{
 }
 
 // NewGraceful returns a goa application that uses a graceful shutdown server.
-func NewGraceful(name string) Service {
+func NewGraceful(name string, cancelOnShutdown bool) Service {
 	app, _ := New(name).(*Application)
-	return &GracefulApplication{Application: app}
+	return &GracefulApplication{Application: app, CancelOnShutdown: cancelOnShutdown}
 }
 
 // ListenAndServe starts the HTTP server and sets up a listener on the given host/port.
@@ -77,7 +80,9 @@ func (gapp *GracefulApplication) Shutdown() bool {
 	}
 	gapp.Interrupted = true
 	gapp.server.Stop(0)
-	Cancel()
+	if gapp.CancelOnShutdown {
+		Cancel()
+	}
 	return true
 }
 

--- a/graceful.go
+++ b/graceful.go
@@ -30,7 +30,8 @@ type GracefulApplication struct {
 	// Interrupted is true if the application is in the process of shutting down.
 	Interrupted bool
 
-	// CancelOnShutdown tells whether existing requests should be canceled when shutdown is triggered.
+	// CancelOnShutdown tells whether existing requests should be canceled when shutdown is
+	// triggered (true) or whether to wait until the requests complete (false).
 	CancelOnShutdown bool
 }
 


### PR DESCRIPTION
Graceful application currently cancels existing requests by canceling
the context. If this context is used in http requests, the requests get
canceled and thus the graceful application is not very graceful. This
change makes the cancelation configurable.