### PR TITLE
Make basic type optional data structure fields pointers

### DIFF
--- a/design/dsl/api.go
+++ b/design/dsl/api.go
@@ -149,6 +149,10 @@ func BaseParams(dsl func()) {
 	if !executeDSL(dsl, params) {
 		return
 	}
+	params.NonZeroAttributes = make(map[string]bool)
+	for n := range params.Type.ToObject() {
+		params.NonZeroAttributes[n] = true
+	}
 	if a, ok := apiDefinition(false); ok {
 		a.BaseParams = params
 	} else if v, ok := versionDefinition(false); ok {

--- a/design/dsl/runner.go
+++ b/design/dsl/runner.go
@@ -184,7 +184,7 @@ func finalizeResource(r *design.ResourceDefinition) {
 				for _, wc := range wcs {
 					found := false
 					var o design.Object
-					if all := a.AllParams(); all != nil {
+					if all := a.Params; all != nil {
 						o = all.Type.ToObject()
 					} else {
 						o = design.Object{}
@@ -203,13 +203,15 @@ func finalizeResource(r *design.ResourceDefinition) {
 				return nil
 			})
 		}
-		// 3. Compute QueryParams from Params
+		// 3. Compute QueryParams from Params and set all path params as non zero attributes
 		if params := a.Params; params != nil {
 			queryParams := params.Dup()
+			a.Params.NonZeroAttributes = make(map[string]bool)
 			design.Design.IterateVersions(func(ver *design.APIVersionDefinition) error {
 				for _, route := range a.Routes {
 					pnames := route.Params(ver)
 					for _, pname := range pnames {
+						a.Params.NonZeroAttributes[pname] = true
 						delete(queryParams.Type.ToObject(), pname)
 					}
 				}
@@ -219,6 +221,7 @@ func finalizeResource(r *design.ResourceDefinition) {
 			// to actual attributes cos' we just deleted them but that's probably OK.)
 			a.QueryParams = queryParams
 		}
+
 		return nil
 	})
 }

--- a/goagen/codegen/types_test.go
+++ b/goagen/codegen/types_test.go
@@ -34,7 +34,7 @@ var _ = Describe("code generation", func() {
 				if required != nil {
 					att.Validations = []ValidationDefinition{required}
 				}
-				st = codegen.GoTypeDef(att, false, "", 0, true, false)
+				st = codegen.GoTypeDef(att, false, "", 0, true)
 			})
 
 			Context("of primitive types", func() {
@@ -48,8 +48,8 @@ var _ = Describe("code generation", func() {
 
 				It("produces the struct go code", func() {
 					expected := "struct {\n" +
-						"	Bar string `json:\"bar,omitempty\"`\n" +
-						"	Foo int `json:\"foo,omitempty\"`\n" +
+						"	Bar *string `json:\"bar,omitempty\"`\n" +
+						"	Foo *int `json:\"foo,omitempty\"`\n" +
 						"}"
 					Ω(st).Should(Equal(expected))
 				})
@@ -106,9 +106,9 @@ var _ = Describe("code generation", func() {
 				It("produces the struct go code", func() {
 					expected := "struct {\n" +
 						"	Foo map[*struct {\n" +
-						"		KeyAtt string `json:\"keyAtt,omitempty\"`\n" +
+						"		KeyAtt *string `json:\"keyAtt,omitempty\"`\n" +
 						"	}]*struct {\n" +
-						"		ElemAtt int `json:\"elemAtt,omitempty\"`\n" +
+						"		ElemAtt *int `json:\"elemAtt,omitempty\"`\n" +
 						"	} `json:\"foo,omitempty\"`\n" +
 						"}"
 					Ω(st).Should(Equal(expected))
@@ -131,7 +131,7 @@ var _ = Describe("code generation", func() {
 				It("produces the struct go code", func() {
 					expected := "struct {\n" +
 						"	Foo []*struct {\n" +
-						"		Bar int `json:\"bar,omitempty\"`\n" +
+						"		Bar *int `json:\"bar,omitempty\"`\n" +
 						"	} `json:\"foo,omitempty\"`\n" +
 						"}"
 					Ω(st).Should(Equal(expected))
@@ -165,7 +165,7 @@ var _ = Describe("code generation", func() {
 			JustBeforeEach(func() {
 				array := &Array{ElemType: elemType}
 				att := &AttributeDefinition{Type: array}
-				source = codegen.GoTypeDef(att, false, "", 0, true, false)
+				source = codegen.GoTypeDef(att, false, "", 0, true)
 			})
 
 			Context("of primitive type", func() {
@@ -189,7 +189,7 @@ var _ = Describe("code generation", func() {
 				})
 
 				It("produces the array go code", func() {
-					Ω(source).Should(Equal("[]*struct {\n\tBar string `json:\"bar,omitempty\"`\n\tFoo int `json:\"foo,omitempty\"`\n}"))
+					Ω(source).Should(Equal("[]*struct {\n\tBar *string `json:\"bar,omitempty\"`\n\tFoo *int `json:\"foo,omitempty\"`\n}"))
 				})
 			})
 		})
@@ -645,7 +645,7 @@ const (
 
 	simpleUnmarshaled = `	if val, ok := raw.(map[string]interface{}); ok {
 		p = new(struct {
-			Foo int
+			Foo *int
 		})
 		if v, ok := val["foo"]; ok {
 			var tmp1 int
@@ -654,7 +654,7 @@ const (
 			} else {
 				err = goa.InvalidAttributeTypeError(` + "`" + `.Foo` + "`" + `, v, "int", err)
 			}
-			p.Foo = tmp1
+			p.Foo = &tmp1
 		}
 	} else {
 		err = goa.InvalidAttributeTypeError(` + "``" + `, raw, "dictionary", err)
@@ -686,19 +686,19 @@ const (
 		p = new(struct {
 			Baz *struct {
 				Bar [][]int
-				Foo int
+				Foo *int
 			}
-			Faz int
+			Faz *int
 		})
 		if v, ok := val["baz"]; ok {
 			var tmp1 *struct {
 				Bar [][]int
-				Foo int
+				Foo *int
 			}
 			if val, ok := v.(map[string]interface{}); ok {
 				tmp1 = new(struct {
 					Bar [][]int
-					Foo int
+					Foo *int
 				})
 				if v, ok := val["bar"]; ok {
 					var tmp2 [][]int
@@ -730,7 +730,7 @@ const (
 					} else {
 						err = goa.InvalidAttributeTypeError(` + "`" + `.Baz.Foo` + "`" + `, v, "int", err)
 					}
-					tmp1.Foo = tmp5
+					tmp1.Foo = &tmp5
 				}
 			} else {
 				err = goa.InvalidAttributeTypeError(` + "`" + `.Baz` + "`" + `, v, "dictionary", err)
@@ -744,7 +744,7 @@ const (
 			} else {
 				err = goa.InvalidAttributeTypeError(` + "`" + `.Faz` + "`" + `, v, "int", err)
 			}
-			p.Faz = tmp6
+			p.Faz = &tmp6
 		}
 	} else {
 		err = goa.InvalidAttributeTypeError(` + "``" + `, raw, "dictionary", err)

--- a/goagen/codegen/validation_test.go
+++ b/goagen/codegen/validation_test.go
@@ -25,7 +25,7 @@ var _ = Describe("validation code generation", func() {
 			JustBeforeEach(func() {
 				att.Type = attType
 				att.Validations = validations
-				code = codegen.ValidationChecker(att, false, target, context, 1)
+				code = codegen.ValidationChecker(att, false, false, target, context, 1)
 			})
 
 			Context("of enum", func() {
@@ -60,13 +60,15 @@ var _ = Describe("validation code generation", func() {
 })
 
 const (
-	enumValCode = `	if !(val == 1 || val == 2 || val == 3) {
-		err = goa.InvalidEnumValueError(` + "`context`" + `, val, []interface{}{1, 2, 3}, err)
+	enumValCode = `	if val != nil {
+		if !(*val == 1 || *val == 2 || *val == 3) {
+			err = goa.InvalidEnumValueError(` + "`context`" + `, *val, []interface{}{1, 2, 3}, err)
+		}
 	}`
 
-	patternValCode = `	if val != "" {
-		if ok := goa.ValidatePattern(` + "`.*`" + `, val); !ok {
-			err = goa.InvalidPatternError(` + "`context`" + `, val, ` + "`.*`" + `, err)
+	patternValCode = `	if val != nil {
+		if ok := goa.ValidatePattern(` + "`.*`" + `, *val); !ok {
+			err = goa.InvalidPatternError(` + "`context`" + `, *val, ` + "`.*`" + `, err)
 		}
 	}`
 )

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/raphael/goa/design"
+	"github.com/raphael/goa/goagen/codegen"
 	"github.com/raphael/goa/goagen/gen_app"
 )
 
@@ -18,6 +19,7 @@ var _ = Describe("ContextsWriter", func() {
 		var err error
 		writer, err = genapp.NewContextsWriter(filename)
 		Ω(err).ShouldNot(HaveOccurred())
+		codegen.TempCount = 0
 	})
 
 	Context("correctly configured", func() {
@@ -573,9 +575,7 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	intContext = `
 type ListBottleContext struct {
 	*goa.Context
-	Param int
-
-	HasParam bool
+	Param *int
 }
 `
 
@@ -586,11 +586,12 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	rawParam := c.Get("param")
 	if rawParam != "" {
 		if param, err2 := strconv.Atoi(rawParam); err2 == nil {
-			ctx.Param = int(param)
+			tmp2 := int(param)
+			tmp1 := &tmp2
+			ctx.Param = tmp1
 		} else {
 			err = goa.InvalidParamTypeError("param", rawParam, "integer", err)
 		}
-		ctx.HasParam = true
 	}
 	return &ctx, err
 }
@@ -599,9 +600,7 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	strContext = `
 type ListBottleContext struct {
 	*goa.Context
-	Param string
-
-	HasParam bool
+	Param *string
 }
 `
 
@@ -611,8 +610,7 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	ctx := ListBottleContext{Context: c}
 	rawParam := c.Get("param")
 	if rawParam != "" {
-		ctx.Param = rawParam
-		ctx.HasParam = true
+		ctx.Param = &rawParam
 	}
 	return &ctx, err
 }
@@ -621,9 +619,7 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	numContext = `
 type ListBottleContext struct {
 	*goa.Context
-	Param float64
-
-	HasParam bool
+	Param *float64
 }
 `
 
@@ -634,11 +630,11 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	rawParam := c.Get("param")
 	if rawParam != "" {
 		if param, err2 := strconv.ParseFloat(rawParam, 64); err2 == nil {
-			ctx.Param = param
+			tmp1 := &param
+			ctx.Param = tmp1
 		} else {
 			err = goa.InvalidParamTypeError("param", rawParam, "number", err)
 		}
-		ctx.HasParam = true
 	}
 	return &ctx, err
 }
@@ -646,9 +642,7 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	boolContext = `
 type ListBottleContext struct {
 	*goa.Context
-	Param bool
-
-	HasParam bool
+	Param *bool
 }
 `
 
@@ -659,11 +653,11 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	rawParam := c.Get("param")
 	if rawParam != "" {
 		if param, err2 := strconv.ParseBool(rawParam); err2 == nil {
-			ctx.Param = param
+			tmp1 := &param
+			ctx.Param = tmp1
 		} else {
 			err = goa.InvalidParamTypeError("param", rawParam, "boolean", err)
 		}
-		ctx.HasParam = true
 	}
 	return &ctx, err
 }
@@ -673,8 +667,6 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 type ListBottleContext struct {
 	*goa.Context
 	Param []string
-
-	HasParam bool
 }
 `
 
@@ -686,7 +678,6 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	if rawParam != "" {
 		elemsParam := strings.Split(rawParam, ",")
 		ctx.Param = elemsParam
-		ctx.HasParam = true
 	}
 	return &ctx, err
 }
@@ -696,8 +687,6 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 type ListBottleContext struct {
 	*goa.Context
 	Param []int
-
-	HasParam bool
 }
 `
 
@@ -717,7 +706,6 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 			}
 		}
 		ctx.Param = elemsParam2
-		ctx.HasParam = true
 	}
 	return &ctx, err
 }
@@ -726,9 +714,7 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	resContext = `
 type ListBottleContext struct {
 	*goa.Context
-	Int int
-
-	HasInt bool
+	Int *int
 }
 `
 
@@ -739,11 +725,12 @@ func NewListBottleContext(c *goa.Context) (*ListBottleContext, error) {
 	rawInt := c.Get("int")
 	if rawInt != "" {
 		if int_, err2 := strconv.Atoi(rawInt); err2 == nil {
-			ctx.Int = int(int_)
+			tmp2 := int(int_)
+			tmp1 := &tmp2
+			ctx.Int = tmp1
 		} else {
 			err = goa.InvalidParamTypeError("int", rawInt, "integer", err)
 		}
-		ctx.HasInt = true
 	}
 	return &ctx, err
 }

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -557,7 +557,7 @@ func (cmd *{{$cmdName}}) Run(c *client.Client) (*http.Response, error) {
 {{else}}			return nil, fmt.Errorf("failed to deserialize payload: %s", err)
 {{end}}		}
 	}
-{{end}}	return c.{{goify (printf "%s%s" .Action.Name (title .Resource.Name)) true}}(cmd.Path{{if .Action.Payload}}, {{if .Action.Payload}}{{if .Action.Payload.Type.IsObject}}&{{end}}payload{{else}}nil{{end}}{{end}}{{/*
+{{end}}	return c.{{goify (printf "%s%s" .Action.Name (title .Resource.Name)) true}}(cmd.Path{{if .Action.Payload}}, {{if or .Action.Payload.Type.IsObject .Action.Payload.IsPrimitive}}&{{end}}payload{{else}}nil{{end}}{{/*
 	*/}}{{$params := joinNames .Action.QueryParams}}{{if $params}}, {{$params}}{{end}}{{/*
 	*/}}{{$headers := joinNames .Action.Headers}}{{if $headers}}, {{$headers}}{{end}})
 }
@@ -578,7 +578,7 @@ func (cmd *{{$cmdName}}) RegisterFlags(cc *kingpin.CmdClause) {
 `
 
 const clientsTmpl = `{{$payload := goify (printf "%s%sPayload" .Name (title .Parent.Name)) true}}{{if .Payload}}// {{$payload}} is the data structure used to initialize the {{.Parent.Name}} {{.Name}} request body.
-type {{$payload}} {{gotypedef .Payload false "" 1 true false}}
+type {{$payload}} {{gotypedef .Payload false "" 1 false}}
 
 {{end}}{{$funcName := goify (printf "%s%s" .Name (title .Parent.Name)) true}}{{$desc := .Description}}{{if $desc}}// {{$desc}}{{else}}// {{$funcName}} makes a request to the {{.Name}} action endpoint of the {{.Parent.Name}} resource{{end}}
 func (c *Client) {{$funcName}}(path string{{if .Payload}}, payload {{if .Payload.Type.IsObject}}*{{end}}{{$payload}}{{end}}{{/*


### PR DESCRIPTION
This PR fixes #127. Before this PR the following DSL:
```go
var MyType = Type("my_type", func() {
        Attribute("foo", Integer)
})
```
would generate the following data structure:
```go
type MyType struct {
        Foo int
}
```
The changes in this PR produce the following:
```go
type MyType struct {
        Foo *int
}
```
Required attributes still generate non-pointer fields:
```go
var MyType = Type("my_type", func() {
        Attribute("foo", Integer)
        Required("foo")
})
```
generates:
```go
type MyType struct {
        Foo int
}
```
The changes also remove the `HasXXX` fields that were generated in the contexts. The client code should now check whether the pointer is nil instead.