### PR TITLE
Use service encoders to marshal response.

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Context", func() {
 			app = goa.New(appName)
 			handler = func(c *goa.Context) error {
 				ctx = c
-				c.Respond(respStatus, respContent)
+				c.RespondBytes(respStatus, respContent)
 				return nil
 			}
 			unmarshaler = func(c *goa.Context) error {
@@ -144,7 +144,7 @@ var _ = Describe("Context", func() {
 			handleFunc(rw, request, params)
 		})
 
-		Describe("Respond", func() {
+		Describe("RespondBytes", func() {
 			It("sets the context fields", func() {
 				Ω(ctx.Request()).Should(Equal(request))
 				Ω(ctx.Header()).Should(Equal(rw.Header()))
@@ -161,18 +161,18 @@ var _ = Describe("Context", func() {
 			})
 		})
 
-		Context("JSON", func() {
+		Context("Respond", func() {
 			BeforeEach(func() {
 				handler = func(c *goa.Context) error {
 					ctx = c
-					c.JSON(respStatus, string(respContent))
+					c.Respond(respStatus, string(respContent))
 					return nil
 				}
 			})
 
 			It("sets the context response fields with the JSON", func() {
 				Ω(ctx.ResponseStatus()).Should(Equal(respStatus))
-				Ω(ctx.ResponseLength()).Should(Equal(len(respContent) + 2)) // quotes
+				Ω(ctx.ResponseLength()).Should(Equal(len(respContent) + 3)) // quotes and newline
 			})
 		})
 

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -295,7 +295,7 @@ func (ctx *GetWidgetContext) OK(resp {{if .version}}app.{{end}}ID) error {
 		return fmt.Errorf("invalid response: %s", err)
 	}
 	ctx.Header().Set("Content-Type", "vnd.rightscale.codegen.test.widgets; charset=utf-8")
-	return ctx.JSON(200, r)
+	return ctx.Respond(200, r)
 }
 `
 

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -463,7 +463,7 @@ func (ctx *{{$ctx.Name}}) {{goify .Name true}}({{/*
 		return fmt.Errorf("invalid response: %s", err)
 	}
 	ctx.Header().Set("Content-Type", "{{$mt.Identifier}}; charset=utf-8")
-	return ctx.JSON({{.Status}}, r){{else}}	return ctx.Respond({{.Status}}, {{if and (not $mt) .MediaType}}resp{{else}}nil{{end}}){{end}}
+	return ctx.Respond({{.Status}}, r){{else}}	return ctx.RespondBytes({{.Status}}, {{if and (not $mt) .MediaType}}resp{{else}}nil{{end}}){{end}}
 }
 
 {{end}}`

--- a/middleware.go
+++ b/middleware.go
@@ -223,7 +223,7 @@ func Recover() Middleware {
 							// the source code.
 							message = err.Error()
 						}
-						ctx.Respond(status, []byte(message))
+						ctx.RespondBytes(status, []byte(message))
 					}
 				}
 			}()
@@ -299,7 +299,7 @@ func RequireHeader(
 				if matched {
 					err = h(ctx)
 				} else {
-					err = ctx.Respond(failureStatus, []byte(http.StatusText(failureStatus)))
+					err = ctx.RespondBytes(failureStatus, []byte(http.StatusText(failureStatus)))
 				}
 			} else {
 				err = h(ctx)

--- a/service.go
+++ b/service.go
@@ -350,7 +350,7 @@ func (ctrl *ApplicationController) HandleFunc(name string, h, d Handler) HandleF
 		handler := middleware
 		if err != nil {
 			handler = func(ctx *Context) error {
-				ctx.Respond(400, []byte(fmt.Sprintf(`{"kind":"invalid request","msg":"invalid JSON: %s"}`, err)))
+				ctx.RespondBytes(400, []byte(fmt.Sprintf(`{"kind":"invalid request","msg":"invalid JSON: %s"}`, err)))
 				return nil
 			}
 			for i := range chain {
@@ -377,7 +377,7 @@ func DefaultErrorHandler(c *Context, e error) {
 		c.Header().Set("Content-Type", "application/json")
 		status = 400
 	}
-	if err := c.Respond(status, []byte(e.Error())); err != nil {
+	if err := c.RespondBytes(status, []byte(e.Error())); err != nil {
 		Log.Error("failed to send default error handler response", "err", err)
 	}
 }
@@ -392,7 +392,7 @@ func TerseErrorHandler(c *Context, e error) {
 		status = 400
 		body = []byte(e.Error())
 	}
-	if err := c.Respond(status, body); err != nil {
+	if err := c.RespondBytes(status, body); err != nil {
 		Log.Error("failed to send terse error handler response", "err", err)
 	}
 }

--- a/service_test.go
+++ b/service_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Application", func() {
 		BeforeEach(func() {
 			handler = func(c *goa.Context) error {
 				ctx = c
-				c.Respond(respStatus, respContent)
+				c.RespondBytes(respStatus, respContent)
 				return nil
 			}
 			unmarshaler = func(c *goa.Context) error {


### PR DESCRIPTION
Rename the JSON method of Context to Respond to reflect the
fact that multiple encodings are now supported. Rename the
previous Respond into RespondBytes.