### PR TITLE
Fix whitespace in dsl godoc comments

### DIFF
--- a/design/dsl/action.go
+++ b/design/dsl/action.go
@@ -15,34 +15,33 @@ import (
 // identical name in the resource default media type). Action definitions also describe all the
 // possible responses including the HTTP status, headers and body. Here is an example showing all
 // the possible sub-definitions:
-//
-//	 Action("Update", func() {
-//	     Description("Update account")
-//           Docs(func() {
-//               Description("Update docs")
-//               URL("http//cellarapi.com/docs/actions/update")
-//           })
-//           Scheme("http")
-//	     Routing(
-//	         PUT("/:id"),                     // Full action path is built by appending "/:id" to parent resource base path
-//	         PUT("//orgs/:org/accounts/:id"), // The // prefix indicates an absolute path
-//	     )
-//	     Params(func() {                      // Params describe the action parameters
-//	         Param("org", String)             // Parameters may correspond to path wildcards
-//	         Param("id", Integer)
-//	         Param("sort", func() {           // or URL query string values.
-//			Enum("asc", desc")
-//		 })
-//	     })
-//	     Headers(func() {                     // Headers describe relevant action headers
-//	         Header("Authorization", String)
-//	         Header("X-Account", Integer)
-//	         Required("Authorization", "X-Account")
-//	     })
-//	     Payload(UpdatePayload)               // Payload describes the HTTP request body (here using a type)
-//	     Response(NoContent)                  // Each possible HTTP response is described via Response
-//	     Response(NotFound)
-//	 })
+//	Action("Update", func() {
+//		Description("Update account")
+//		Docs(func() {
+//			Description("Update docs")
+//			URL("http//cellarapi.com/docs/actions/update")
+//		})
+//		Scheme("http")
+//		Routing(
+//			PUT("/:id"),				// Full action path is built by appending "/:id" to parent resource base path
+//			PUT("//orgs/:org/accounts/:id"),	// The // prefix indicates an absolute path
+//		)
+//		Params(func() {					// Params describe the action parameters
+//			Param("org", String)			// Parameters may correspond to path wildcards
+//			Param("id", Integer)
+//			Param("sort", func() {			// or URL query string values.
+//				Enum("asc", "desc")
+//			})
+//		})
+//		Headers(func() {				// Headers describe relevant action headers
+//			Header("Authorization", String)
+//			Header("X-Account", Integer)
+//			Required("Authorization", "X-Account")
+//		})
+//		Payload(UpdatePayload)				// Payload describes the HTTP request body (here using a type)
+//		Response(NoContent)				// Each possible HTTP response is described via Response
+//		Response(NotFound)
+//	})
 func Action(name string, dsl func()) {
 	if r, ok := resourceDefinition(true); ok {
 		if r.Actions == nil {
@@ -167,8 +166,8 @@ func Headers(dsl func()) {
 // as the Attribute DSL. Here is an example:
 //
 //	Params(func() {
-//		Param("id", Integer)            // A path parameter defined using e.g. GET("/:id")
-//		Param("sort", String, func() {  // A query string parameter
+//		Param("id", Integer)		// A path parameter defined using e.g. GET("/:id")
+//		Param("sort", String, func() {	// A query string parameter
 //			Enum("asc", "desc")
 //		})
 //	})
@@ -194,15 +193,15 @@ func Params(dsl func()) {
 // using the Member DSL which accepts the same syntax as the Attribute DSL. This function can be
 // called passing in a type, a DSL or both. Examples:
 //
-//	 Payload(BottlePayload)	   // Request payload is described by the BottlePayload type
+//	Payload(BottlePayload)		// Request payload is described by the BottlePayload type
 //
-//	 Payload(func() {          // Request payload is an object and is described inline
-//	 	Member("Name")
-//	 })
+//	Payload(func() {		// Request payload is an object and is described inline
+//		Member("Name")
+//	})
 //
-//	 Payload(BottlePayload, func() { // Request payload is described by merging the inline
-//	 	Required("Name")         // definition into the BottlePayload type.
-//	 })
+//	Payload(BottlePayload, func() {	// Request payload is described by merging the inline
+//		Required("Name")	// definition into the BottlePayload type.
+//	})
 //
 func Payload(p interface{}, dsls ...func()) {
 	if len(dsls) > 1 {

--- a/design/dsl/api.go
+++ b/design/dsl/api.go
@@ -12,9 +12,9 @@ import (
 // default global property values for all API versions. Here is an example showing all the possible
 // API sub-definitions:
 //
-// 	API("API name", func() {
-// 		Title("title")                          // API title used in documentation
-// 		Description("description")              // API description used in documentation
+//	API("API name", func() {
+//		Title("title")				// API title used in documentation
+//		Description("description")		// API description used in documentation
 //		TermsOfService("terms")
 //		Contact(func() {			// API Contact information
 //			Name("contact name")
@@ -29,29 +29,29 @@ import (
 //			Description("doc description")
 //			URL("doc URL")
 //		})
-//		Host("goa.design")                      // API hostname
+//		Host("goa.design")			// API hostname
 //		Scheme("http")
-// 		BasePath("/base/:param")                // Common base path to all API actions
-// 		BaseParams(func() {                     // Common parameters to all API actions
-// 			Param("param")
-// 		})
-// 		ResponseTemplate("static", func() {     // Response template for use by actions
-// 			Description("description")
-// 			Status(404)
-// 			MediaType("application/json")
-// 		})
-// 		ResponseTemplate("dynamic", func(arg1, arg2 string) {
-// 			Description(arg1)
-// 			Status(200)
-// 			MediaType(arg2)
-// 		})
-// 		Trait("Authenticated", func() {         // Traits define DSL that can be run anywhere
-// 			Headers(func() {
-// 				Header("header")
-// 				Required("header")
-// 			})
-// 		})
-// 	}
+//		BasePath("/base/:param")		// Common base path to all API actions
+//		BaseParams(func() {			// Common parameters to all API actions
+//			Param("param")
+//		})
+//		ResponseTemplate("static", func() {	// Response template for use by actions
+//			Description("description")
+//			Status(404)
+//			MediaType("application/json")
+//		})
+//		ResponseTemplate("dynamic", func(arg1, arg2 string) {
+//			Description(arg1)
+//			Status(200)
+//			MediaType(arg2)
+//		})
+//		Trait("Authenticated", func() {		// Traits define DSL that can be run anywhere
+//			Headers(func() {
+//				Header("header")
+//				Required("header")
+//			})
+//		})
+//	}
 //
 func API(name string, dsl func()) *design.APIDefinition {
 	// We can't rely on this being run first, any of the top level DSL could run
@@ -285,13 +285,13 @@ func URL(url string) {
 // media type:
 //
 //	ResponseTemplate(OK, func(mt string) {
-//		Status(200)                             // OK response uses status code 200
-//		Media(mt)                               // Media type name set by action definition
+//		Status(200)				// OK response uses status code 200
+//		Media(mt)				// Media type name set by action definition
 //		Headers(func() {
-//			Header("X-Request-Id", func() { // X-Request-Id header contains a string
-//				Pattern("[0-9A-F]+")    // Regexp used to validate the response header content
+//			Header("X-Request-Id", func() {	// X-Request-Id header contains a string
+//				Pattern("[0-9A-F]+")	// Regexp used to validate the response header content
 //			})
-//			Required("X-Request-Id")        // Header is mandatory
+//			Required("X-Request-Id")	// Header is mandatory
 //		})
 //	})
 //

--- a/design/dsl/attribute.go
+++ b/design/dsl/attribute.go
@@ -31,48 +31,48 @@ import (
 // on where the definition appears. The syntax for all these DSL is the same.
 // Here are some examples:
 //
-//	 Attribute("name")             //  Defines an attribute of type String
+//	Attribute("name")					// Defines an attribute of type String
 //
-//	 Attribute("name", func() {
-//	 	Pattern("^foo")        // Adds a validation rule to the attribute
-//	 })
+//	Attribute("name", func() {
+//		Pattern("^foo")					// Adds a validation rule to the attribute
+//	})
 //
-//	 Attribute("name", Integer)    // Defines an attribute of type Integer
+//	Attribute("name", Integer)				// Defines an attribute of type Integer
 //
-//	 Attribute("name", Integer, func() {
-//	 	Default(42)            // With a default value
-//	 })
+//	Attribute("name", Integer, func() {
+//		Default(42)					// With a default value
+//	})
 //
-//	 Attribute("name", Integer, "description") // Specifies a description
+//	Attribute("name", Integer, "description")		// Specifies a description
 //
-//	 Attribute("name", Integer, "description", func() {
-//	 	Enum(1, 2)             // And validation rules
-//	 })
+//	Attribute("name", Integer, "description", func() {
+//		Enum(1, 2)					// And validation rules
+//	})
 //
 // Nested attributes:
 //
-//	 Attribute("nested", func() {
-//	 	Description("description")
-//	 	Attribute("child")
-//	 	Attribute("child2", func() {
-//	 		// ....
-//	 	})
-//              Required("child")
-//	 })
+//	Attribute("nested", func() {
+//		Description("description")
+//		Attribute("child")
+//		Attribute("child2", func() {
+//			// ....
+//		})
+//		Required("child")
+//	})
 //
 // Here are all the valid usage of the Attribute function:
 //
-//	 Attribute(name string, dataType DataType, description string, dsl func())
+//	Attribute(name string, dataType DataType, description string, dsl func())
 //
-//	 Attribute(name string, dataType DataType, description string)
+//	Attribute(name string, dataType DataType, description string)
 //
-//	 Attribute(name string, dataType DataType, dsl func())
+//	Attribute(name string, dataType DataType, dsl func())
 //
-//	 Attribute(name string, dataType DataType)
+//	Attribute(name string, dataType DataType)
 //
-//	 Attribute(name string, dsl func()) /* dataType is String or Object (if DSL defines child attributes) */
+//	Attribute(name string, dsl func())	// dataType is String or Object (if DSL defines child attributes)
 //
-//	 Attribute(name string) /* dataType is String */
+//	Attribute(name string)			// dataType is String
 func Attribute(name string, args ...interface{}) {
 	var parent *design.AttributeDefinition
 	if at, ok := attributeDefinition(false); ok {

--- a/design/dsl/media_type.go
+++ b/design/dsl/media_type.go
@@ -26,7 +26,7 @@ var mediaTypeCount int
 // special "link" view. Media types that are linked to must define that view. Here is an example
 // showing all the possible media type sub-definitions:
 //
-// 	MediaType("application/vnd.goa.example.bottle", func() {
+//	MediaType("application/vnd.goa.example.bottle", func() {
 //		Description("A bottle of wine")
 //		APIVersion("1.0")
 //		Attributes(func() {
@@ -35,22 +35,22 @@ var mediaTypeCount int
 //			Attribute("account", Account, "Owner account")
 //			Attribute("origin", Origin, "Details on wine origin")
 //			Links(func() {
-//				Link("account")        // Defines a link to the Account media type
-//				Link("origin", "tiny") // Overrides the default view used to render links
+//				Link("account")		// Defines a link to the Account media type
+//				Link("origin", "tiny")	// Overrides the default view used to render links
 //			})
-//              	Required("id", "href")
-//     		 })
+//			Required("id", "href")
+//		})
 //		View("default", func() {
 //			Attribute("id")
 //			Attribute("href")
-//			Attribute("links") // Default view renders links
+//			Attribute("links")	// Default view renders links
 //		})
 //		View("extended", func() {
 //			Attribute("id")
 //			Attribute("href")
-//			Attribute("account") // Extended view renders account inline
-//			Attribute("origin")  // Extended view renders origin inline
-//			Attribute("links")   // Extended view also renders links
+//			Attribute("account")	// Extended view renders account inline
+//			Attribute("origin")	// Extended view renders origin inline
+//			Attribute("links")	// Extended view also renders links
 //		})
 // 	})
 //
@@ -125,7 +125,7 @@ func MediaType(identifier string, dsl func()) *design.MediaTypeDefinition {
 
 // Media sets a response media type by name or by reference using a value returned by MediaType:
 //
-// 	Response("NotFound", func() {
+//	Response("NotFound", func() {
 //		Status(404)
 //		Media("application/json")
 //	})
@@ -149,7 +149,7 @@ func Media(val interface{}) {
 // The reference type attributes define the default properties for attributes with the same name in
 // the type using the reference. So for example if a type is defined as such:
 //
-// 	var Bottle = Type("bottle", func() {
+//	var Bottle = Type("bottle", func() {
 //		Attribute("name", func() {
 //			MinLength(3)
 //		})
@@ -161,7 +161,7 @@ func Media(val interface{}) {
 //
 // Declaring the following media type:
 //
-// 	var BottleMedia = MediaType("vnd.goa.bottle", func() {
+//	var BottleMedia = MediaType("vnd.goa.bottle", func() {
 //		Reference(Bottle)
 //		Attributes(func() {
 //			Attribute("id", Integer)
@@ -199,7 +199,7 @@ func TypeName(name string) {
 // specified then the view named "default" is used. Examples:
 //
 //	View("default", func() {
-//		Attribute("id")         // "id" and "name" must be media type attributes
+//		Attribute("id")		// "id" and "name" must be media type attributes
 //		Attribute("name")
 //	})
 //
@@ -207,7 +207,7 @@ func TypeName(name string) {
 //		Attribute("id")
 //		Attribute("name")
 //		Attribute("origin", func() {
-//			View("extended") // Use view "extended" to render attribute "origin"
+//			View("extended")	// Use view "extended" to render attribute "origin"
 //		})
 //	})
 func View(name string, dsl ...func()) {
@@ -289,8 +289,8 @@ func Links(dsl func()) {
 // media type attribute names. A link may also define the view used to render the linked-to
 // attribute. The default view used to render links is "link". Examples:
 //
-// 	Link("origin")           // Use the "link" view of the "origin" attribute
-//	Link("account", "tiny")  // Use the "tiny" view of the "account" attribute
+//	Link("origin")		// Use the "link" view of the "origin" attribute
+//	Link("account", "tiny")	// Use the "tiny" view of the "account" attribute
 func Link(name string, view ...string) {
 	if mt, ok := mediaTypeDefinition(true); ok {
 		if mt.Links == nil {

--- a/design/dsl/resource.go
+++ b/design/dsl/resource.go
@@ -21,18 +21,18 @@ import "github.com/raphael/goa/design"
 // via CanonicalActionName to override that default. Here is an example of a resource definition:
 //
 //	Resource("bottle", func() {
-//		Description("A wine bottle") // Resource description
-//		DefaultMedia(BottleMedia)    // Resource default media type
-//		BasePath("/bottles")         // Common resource action path prefix if not ""
-//		Parent("account")            // Name of parent resource if any
-//		CanonicalActionName("get")   // Name of action that returns canonical representation if not "show"
-//		UseTrait("Authenticated")    // Included trait if any, can appear more than once
-//		APIVersion("v1")	     // API version exposing this resource, can appear more than once.
+//		Description("A wine bottle")	// Resource description
+//		DefaultMedia(BottleMedia)	// Resource default media type
+//		BasePath("/bottles")		// Common resource action path prefix if not ""
+//		Parent("account")		// Name of parent resource if any
+//		CanonicalActionName("get")	// Name of action that returns canonical representation if not "show"
+//		UseTrait("Authenticated")	// Included trait if any, can appear more than once
+//		APIVersion("v1")		// API version exposing this resource, can appear more than once.
 //
-//	 	Action("show", func() {      // Action definition, can appear more than once
+//		Action("show", func() {		// Action definition, can appear more than once
 //			// ... Action DSL
 //		})
-//	 })
+//	})
 func Resource(name string, dsl func()) *design.ResourceDefinition {
 	if design.Design == nil {
 		InitDesign()
@@ -55,15 +55,15 @@ func Resource(name string, dsl func()) *design.ResourceDefinition {
 // DefaultMedia sets a resource default media type by identifier or by reference using a value
 // returned by MediaType:
 //
-// 	var _ = Resource("bottle", func() {
-// 		DefaultMedia(BottleMedia)
-// 		// ...
-// 	})
+//	var _ = Resource("bottle", func() {
+//		DefaultMedia(BottleMedia)
+//		// ...
+//	})
 //
-// 	var _ = Resource("region", func() {
-// 		DefaultMedia("vnd.goa.region")
-// 		// ...
-// 	})
+//	var _ = Resource("region", func() {
+//		DefaultMedia("vnd.goa.region")
+//		// ...
+//	})
 //
 // The default media type is used to build OK response definitions when no specific media type is
 // given in the Response function call. The default media type is also used to set the default

--- a/design/dsl/response.go
+++ b/design/dsl/response.go
@@ -12,15 +12,15 @@ import "github.com/raphael/goa/design"
 // status code, media type and headers overriding what the default response or response template
 // specifies:
 //
-// 	Response(OK, "vnd.goa.bottle", func() {  // OK response template accepts one argument: the media type identifier
-// 		Headers(func() {                 // Headers list the response HTTP headers, see Headers
-// 			Header("X-Request-Id")
-// 		})
-// 	})
+//	Response(OK, "vnd.goa.bottle", func() {	// OK response template accepts one argument: the media type identifier
+//		Headers(func() {		// Headers list the response HTTP headers, see Headers
+//			Header("X-Request-Id")
+//		})
+//	})
 //
 //	Response(NotFound, func() {
-//		Status(404)               // Not necessary as defined by default NotFound response.
-//		Media("application/json") // Override NotFound response default of "text/plain"
+//		Status(404)			// Not necessary as defined by default NotFound response.
+//		Media("application/json")	// Override NotFound response default of "text/plain"
 //	})
 //
 //	Response(Created, func() {

--- a/design/dsl/type.go
+++ b/design/dsl/type.go
@@ -11,18 +11,18 @@ import "github.com/raphael/goa/design"
 // structure of a request payload. They can also be used by media type definitions as reference, see
 // Reference. Here is an example:
 //
-// Type("createPayload", func() {
-// 	Description("Type of create and upload action payloads")
-//	APIVersion("1.0")
-//	Attribute("name", String, "name of bottle")
-//	Attribute("origin", Origin, "Details on wine origin")  // See Origin definition below
-// 	Required("name")
-// })
+//	Type("createPayload", func() {
+//		Description("Type of create and upload action payloads")
+//		APIVersion("1.0")
+//		Attribute("name", String, "name of bottle")
+//		Attribute("origin", Origin, "Details on wine origin")  // See Origin definition below
+//		Required("name")
+//	})
 //
-// var Origin = Type("origin", func() {
-//	Description("Origin of bottle")
-//	Attribute("Country")
-// })
+//	var Origin = Type("origin", func() {
+//		Description("Origin of bottle")
+//		Attribute("Country")
+//	})
 //
 // This function returns the newly defined type so the value can be used throughout the DSL.
 func Type(name string, dsl func()) *design.UserTypeDefinition {
@@ -84,7 +84,7 @@ func ArrayOf(t design.DataType) *design.Array {
 //
 //	Action("updateRatings", func() {
 //		Payload(func() {
-//			Member("ratings", HashOf(String, Integer)) // Artificial examples...
+//			Member("ratings", HashOf(String, Integer))  // Artificial examples...
 //			Member("bottles", RatedBottles)
 //	})
 func HashOf(k, v design.DataType) *design.Hash {


### PR DESCRIPTION
Action, Attribute, Type, etc have whitespace issues.  Once I got started, I
couldn't stop.  Fixes patterned after encoding/gob.  Use tabs in all of the
preformatted text blocks, even preceeding trailing line comments.  Tab width is
8.